### PR TITLE
Refactor: Migrate to PyPI Trusted Publisher for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,9 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, musllinux, windows, macos, sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/riichienv
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <br />
 
 [![CI](https://github.com/smly/RiichiEnv/actions/workflows/ci.yml/badge.svg)](https://github.com/smly/RiichiEnv/actions/workflows/ci.yml)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/smly/RiichiEnv/demos/replay_demo.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/smly/RiichiEnv/blob/main/demos/replay_demo.ipynb)
 [![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/smly/RiichiEnv/demos/replay_demo.ipynb)
 ![PyPI - Version](https://img.shields.io/pypi/v/riichienv)
 ![License](https://img.shields.io/github/license/smly/riichienv)

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -137,13 +137,21 @@ This project uses an automated GitHub Actions workflow for releases.
 
 ### 1. Prerequisites
 - You need a PyPI account.
-- Generate a **Trusted Publisher** token or an API token on PyPI.
+- **Trusted Publisher Setup**:
+  1. Go to your Project settings on PyPI (or Add a new pending publisher).
+  2. Select **GitHub** as the publisher.
+  3. Enter `pypi` as the **Environment name**.
+  4. The workflow name is `release.yml`, and the job name (optional) can be left blank or set to `release`.
 
-### 2. Configure GitHub Secrets
-1. Go to your repository on GitHub.
-2. Navigate to **Settings** > **Secrets and variables** > **Actions**.
-3. Create a new repository secret named `PYPI_API_TOKEN`.
-4. Paste your PyPI API token as the value.
+### 2. Configure GitHub Settings
+1. **Secrets**:
+   - Go to **Settings** > **Secrets and variables** > **Actions**.
+   - Create a repository secret `PYPI_API_TOKEN` (if using token-based auth) OR ensure your Trusted Publisher setup corresponds to this repo.
+   
+2. **Environments**:
+   - Go to **Settings** > **Environments**.
+   - Create a new environment named `pypi`.
+   - (Optional) Configure "Required reviewers" to require manual approval before publishing.
 
 ### 3. Creating a Release
 To publish a new version:


### PR DESCRIPTION
This PR updates the GitHub Actions release workflow to leverage PyPI's Trusted Publisher feature, enhancing the security of package deployments. It configures the `release` job to use a `pypi` environment, which integrates directly with PyPI's OIDC for secure authentication.

The `DEVELOPMENT_GUIDE.md` has been updated with detailed instructions for setting up Trusted Publishers, reflecting the new, more secure publishing best practices. A minor correction to the Colab badge link in `README.md` is also included.