### PR TITLE
Streamline CI/CD releases with Trusted Publishers and v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
           - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
-            target: armv7
-          - runner: ubuntu-latest
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
@@ -55,8 +53,6 @@ jobs:
             target: x86
           - runner: ubuntu-latest
             target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -107,8 +103,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:
@@ -165,8 +159,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing dist/*

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -137,21 +137,22 @@ This project uses an automated GitHub Actions workflow for releases.
 
 ### 1. Prerequisites
 - You need a PyPI account.
-- **Trusted Publisher Setup**:
-  1. Go to your Project settings on PyPI (or Add a new pending publisher).
-  2. Select **GitHub** as the publisher.
-  3. Enter `pypi` as the **Environment name**.
-  4. The workflow name is `release.yml`, and the job name (optional) can be left blank or set to `release`.
+- **Trusted Publisher Setup** (Recommended, no token needed):
+  1. Go to your [PyPI Publishing settings](https://pypi.org/manage/account/publishing/).
+  2. If the project doesn't exist on PyPI yet, select **Add a new pending publisher**.
+  3. **Project Name**: `riichienv`
+  4. **Owner**: Your GitHub username or organization name.
+  5. **Repository name**: `RiichiEnv`
+  6. **Workflow name**: `release.yml`
+  7. **Environment name**: `pypi`
+  8. Click **Add**.
 
 ### 2. Configure GitHub Settings
-1. **Secrets**:
-   - Go to **Settings** > **Secrets and variables** > **Actions**.
-   - Create a repository secret `PYPI_API_TOKEN` (if using token-based auth) OR ensure your Trusted Publisher setup corresponds to this repo.
-   
-2. **Environments**:
-   - Go to **Settings** > **Environments**.
+1. **Environments**:
+   - Go to your repository **Settings** > **Environments**.
    - Create a new environment named `pypi`.
    - (Optional) Configure "Required reviewers" to require manual approval before publishing.
+   - **Note**: You do *not* need to set `PYPI_API_TOKEN` secret if using Trusted Publisher.
 
 ### 3. Creating a Release
 To publish a new version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riichienv"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     { name="Kohei Ozaki", email="19337+smly@users.noreply.github.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "riichienv"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
This commit improves the release process by integrating PyPI's Trusted Publisher, which removes the dependency on API tokens for publishing. The project version is also incremented.

Changes include:
*   Refactored `.github/workflows/release.yml` to remove `armv7` and `macos-13 x86_64` platforms and to no longer use `PYPI_API_TOKEN`.
*   Documentation in `docs/DEVELOPMENT_GUIDE.md` has been updated to reflect the new Trusted Publisher setup for PyPI.
*   Project version in `pyproject.toml` and `uv.lock` has been updated to `0.1.1`.