### PR TITLE
Refactor: Update GitHub Release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -148,9 +147,9 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - name: Create GitHub Release
+      - name: Upload binaries to release
         run: |
-          gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}" --generate-notes dist/*
+          gh release upload ${{ github.ref_name }} dist/* --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PyPI

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -158,21 +158,22 @@ This project uses an automated GitHub Actions workflow for releases.
 To publish a new version:
 
 1. Update the version number in `pyproject.toml` (e.g., `0.1.0` -> `0.1.1`).
-2. Update the version in `Cargo.toml` (under `[package]` in `native/Cargo.toml`) if necessary, though `maturin` often handles the mismatch or you should keep them in sync.
-3. Commit the changes:
+2. Commit and push the changes:
    ```bash
-   git add pyproject.toml native/Cargo.toml
+   git add pyproject.toml
    git commit -m "chore: bump version to 0.1.1"
    git push
    ```
-4. Create and push a tag starting with `v`:
-   ```bash
-   git tag v0.1.1
-   git push origin v0.1.1
-   ```
+3. **Draft a Release on GitHub**:
+   - Go to the **Releases** page on GitHub.
+   - Click **Draft a new release**.
+   - **Choose a tag**: Create a new tag (e.g., `v0.1.1`) on the target branch.
+   - **Release title**: `v0.1.1` (or your preferred title).
+   - Write your release notes.
+   - Click **Publish release**.
 
 The GitHub Actions workflow will automatically:
+- Trigger when the release is published.
 - Build wheels for Linux, Windows, and macOS.
-- Create a GitHub Release with the changelog.
-- Upload the binary artifacts to the GitHub Release.
+- **Upload the binary artifacts** to your existing release.
 - Publish the package to PyPI.


### PR DESCRIPTION
The GitHub Actions release workflow has been updated to trigger on the `release.published` event instead of `push.tags`. This change ensures that the CI/CD pipeline runs after a release is manually created and published via the GitHub UI, allowing built artifacts to be uploaded to the existing release. The `DEVELOPMENT_GUIDE.md` has been updated to reflect these new steps for creating a release.