### PR TITLE
Update PyPI Publish Action to `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   linux:
@@ -153,7 +154,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+          packages-dir: dist/
+          skip-existing: true


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use the official `pypa/gh-action-pypi-publish` action for publishing packages to PyPI. This change standardizes the publishing process and enables secure OpenID Connect (OIDC) authentication, removing the need for long-lived API tokens.