### PR TITLE
chore(replay-visualizer): remove redundant internal comments

### DIFF
--- a/tools/replay-visualizer/src/index.ts
+++ b/tools/replay-visualizer/src/index.ts
@@ -161,7 +161,7 @@ export class Viewer {
             btnLog.onclick = () => this.controller.toggleLog(btnLog, this.debugPanel);
             rightSidebar.appendChild(btnLog);
 
-            // Hide Button REMOVED
+
 
             const btnPTurn = createBtn('btn-pturn', ICON_ARROW_LEFT, "Prev Round");
             btnPTurn.onclick = () => this.controller.prevTurn();
@@ -183,7 +183,7 @@ export class Viewer {
             btnAuto.onclick = () => this.controller.toggleAutoPlay(btnAuto);
             rightSidebar.appendChild(btnAuto);
 
-            // Pseudo button for Round Selector (hidden or triggered by center?)
+            // Hidden button for Round Selector
             const rBtn = document.createElement('div');
             rBtn.id = 'btn-round';
             rBtn.style.display = 'none';
@@ -222,16 +222,10 @@ export class Viewer {
         }
 
         // Resize Logic to scale the entire content (Board + Sidebar)
-        // Resize Logic to scale the entire content (Board + Sidebar)
-        // We use ResizeObserver on the container to detect size changes of the parent environment (e.g. Jupyter cell)
+        // We use ResizeObserver on the container to detect size changes.
         const resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
-                // The entry.contentRect gives the size of the container.
-                // However, since we adjust the container size ourselves (in older logic),
-                // we must be careful.
-                // Actually, in the latest logic (step 293), we resize `scaleWrapper`, 
-                // and `this.container` is just a flexible wrapper (display: block, maxWidth: 100%).
-                // So `this.container.clientWidth` should reflect the PARENT's constraint.
+                // this.container.clientWidth reflects the PARENT's constraint.
 
                 const availableW = entry.contentRect.width;
                 // For height, we might not be constrained by parent height in Jupyter (it grows).
@@ -263,21 +257,9 @@ export class Viewer {
 
         resizeObserver.observe(this.container);
 
-        // Also keep window resize listener as fallback or for height updates?
-        // ResizeObserver on container usually covers window resizes that affect container width.
-        // But window height changes might not trigger container resize if container is short.
-        // We can add a simple listener to trigger observer logic?
-        // Or just observe document.body?
-        // Let's stick to observing container + window resize.
 
+        // Handle window resize to update vertical scaling if needed
         window.addEventListener('resize', () => {
-            // Force check
-            // But ResizeObserver loop is separate.
-            // We can just rely on ResizeObserver if width changes.
-            // If ONLY height changes (e.g. browser resizing vertically), container width might not change.
-            // But `availableH` from window.innerHeight depends on it.
-            // So we need to re-run logic.
-            // Let's manually run the logic:
             const availableW = this.container.clientWidth;
             const availableH = window.innerHeight;
             const baseW = 970; const baseH = 900;
@@ -353,16 +335,6 @@ export class Viewer {
         kyokus.forEach((k, idx) => {
             const tr = document.createElement('tr');
             tr.onclick = () => {
-                // Jump to this kyoku
-                // Find start_kyoku event index
-                // We know kyokus[idx] corresponds to limits[idx].start
-                // Actually GameState stores limits. 
-                // We need to jump to k.startEventIndex
-                // Wait, GameState kyokus array has { round, honba, scores, startEventIndex }?
-                // Let's assume GameState has a method or list.
-                // Looking at GameState class (inferred), it likely has this info.
-                // For now, let's assume we can jump by index if we had it.
-                // Simplified: use gameState.jumpToKyoku(idx).
                 this.gameState.jumpToKyoku(idx);
                 this.update();
                 overlay.remove();

--- a/tools/replay-visualizer/src/renderer.ts
+++ b/tools/replay-visualizer/src/renderer.ts
@@ -103,8 +103,7 @@ export class Renderer {
                 position: 'relative'
             });
 
-            // Active player highlighting - Removed old highlight
-            // New logic adds bar to infoBox below
+            // Active player highlighting adds bar to infoBox below
             pDiv.style.padding = '10px';
 
             // Call Overlay Logic
@@ -138,7 +137,7 @@ export class Renderer {
                 pDiv.appendChild(overlay);
             }
 
-            // Riichi Stick rendering moved to CenterRenderer
+
 
             // Wait Indicator Logic (Persistent)
             if (p.waits && p.waits.length > 0) {
@@ -158,7 +157,7 @@ export class Renderer {
             }
 
             // --- River + Info Container ---
-            // ABSOLUTE POSITIONED RIVER
+            // Relative positioned river container
             // We use riverRow as the container for the river tiles, absolutely positioned.
             const riverRow = document.createElement('div');
             Object.assign(riverRow.style, {
@@ -197,11 +196,6 @@ export class Renderer {
 
             // Render Hand
             // Check if this player has just drawn a tile (Tsumo position)
-            // Conditions: 
-            // 1. It is this player's turn (active actor)
-            // 2. The last event was 'tsumo' (they drew) OR 'start_kyoku' (Oya's first 14th tile)
-            // Note: After pon/chi/kan, it is their turn but they did NOT draw from wall (they took from river).
-            // So we do NOT separate.
             let hasDraw = false;
             let shouldAnimate = false;
 
@@ -227,11 +221,6 @@ export class Renderer {
 
             const hand = HandRenderer.renderHand(playerState.hand, playerState.melds, i, activeWaits, hasDraw, dAnim, shouldAnimate);
 
-            // HIDE HANDS LOGIC REMOVED
-
-            // Assuming positionElement and handsTarget are part of the class or a refactor
-            // For now, append directly to pDiv as per original structure,
-            // but keep the new hand variable and hide logic.
             pDiv.appendChild(hand);
 
             wrapper.appendChild(pDiv);
@@ -242,22 +231,9 @@ export class Renderer {
         if (state.lastEvent && state.lastEvent.type === 'end_kyoku' && state.lastEvent.meta && state.lastEvent.meta.results) {
             const results = state.lastEvent.meta.results;
             // Use new ResultRenderer
-            // We assume YAKU_MAP is handled internally or passed if needed, but ResultRenderer imports it.
             const modal = ResultRenderer.renderModal(results, state);
 
-            // Allow close by clicking overlay (handled by caller? No, ResultRenderer creates overlay).
-            // We need to support 'removing' it from board.
-            // The renderer.ts recreates content every time, so simply appending it works.
-            // But if user wants to close it?
-            // If the event is still 'end_kyoku', re-render will bring it back.
-            // The modal should perhaps NOT be rendered if the user has dismissed it for this specific event instance?
-            // But usually 'end_kyoku' is a state. You move next to start next kyoku.
-            // So closing it might just hide it. 
-            // Let's add simple click-to-hide logic to the overlay in ResultRenderer or here.
-            // ResultRenderer didn't implement creating a close handler that removes it from DOM.
-            // But since board.innerHTML is cleared on render, 'close' just means removing from DOM *until next render*.
-            // Next render happens on next/prev step.
-            // So clicking background to remove() is fine.
+            // Click background to close
             modal.onclick = (e) => {
                 if (e.target === modal) {
                     modal.remove();


### PR DESCRIPTION
Deletes obsolete and verbose comments, including prior implementation considerations and commented-out code sections, across `game_state.ts`, `index.ts`, and `renderer.ts`. This effort aims to streamline the codebase and enhance readability.