### PR TITLE
feat: Track discard type (Tedashi vs Tsumogiri) in RiichiEnv

### DIFF
--- a/native/src/env.rs
+++ b/native/src/env.rs
@@ -311,6 +311,8 @@ pub struct RiichiEnv {
     #[pyo3(get, set)]
     pub discards: [Vec<u8>; 4],
     #[pyo3(get, set)]
+    pub discard_from_hand: [Vec<bool>; 4],
+    #[pyo3(get, set)]
     pub current_player: u8,
     #[pyo3(get, set)]
     pub turn_count: u32,
@@ -816,6 +818,7 @@ impl RiichiEnv {
             hands: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             melds: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             discards: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+            discard_from_hand: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             current_player: 0,
             turn_count: 0,
             is_done: false,
@@ -2286,6 +2289,7 @@ impl RiichiEnv {
         }
 
         self.discards[pid as usize].push(tile);
+        self.discard_from_hand[pid as usize].push(!tsumogiri);
         self.drawn_tile = None;
         self.last_discard = Some((pid, tile));
 
@@ -2701,6 +2705,7 @@ impl RiichiEnv {
         self.hands = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
         self.melds = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
         self.discards = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        self.discard_from_hand = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
         self.is_done = false;
         self.current_claims = HashMap::new();
         self.pending_kan = None;

--- a/native/src/tests.rs
+++ b/native/src/tests.rs
@@ -156,6 +156,7 @@ mod unit_tests {
             hands: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             melds: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             discards: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
+            discard_from_hand: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             current_player: 0,
             turn_count: 0,
             is_done: false,

--- a/tests/env/test_discard_type.py
+++ b/tests/env/test_discard_type.py
@@ -1,0 +1,61 @@
+from riichienv import Action, ActionType, Phase, RiichiEnv
+
+
+class TestDiscardType:
+    def test_discard_type_tracking(self) -> None:
+        """
+        Verify that `discard_from_hand` correctly tracks whether a discard was
+        Tedashi (True) or Tsumogiri (False).
+        """
+        env = RiichiEnv(seed=42)
+        env.reset()
+
+        # Force a known state
+        # P0 Hands
+        # Make P0 turn
+        env.current_player = 0
+        env.phase = Phase.WaitAct
+
+        # Case 1: Tsumogiri (Discard Drawn Tile)
+        drawn_tile = 10  # 3m
+        env.drawn_tile = drawn_tile
+        # Ensure tile is in hand (simulate draw)
+        # MUST assign back to env.hands to persist change to Rust struct
+        h = env.hands
+        h[0].append(drawn_tile)
+        env.hands = h
+
+        # Action: Discard the drawn tile
+        env.step({0: Action(ActionType.Discard, tile=drawn_tile)})
+
+        # Verify: Last discard for P0 should be Tsumogiri (from_hand=False)
+        assert len(env.discard_from_hand[0]) == 1
+        assert len(env.discards[0]) == 1
+        assert env.discards[0][-1] == drawn_tile
+        assert env.discard_from_hand[0][-1] is False, "Should be Tsumogiri (False)"
+
+        # Case 2: Tedashi (Discard From Hand)
+        # Advance/Reset to P0 again or just force state
+        env.current_player = 0
+        env.phase = Phase.WaitAct
+        env.active_players = [0]
+        env.needs_tsumo = False  # Already "drew" manually below
+
+        new_drawn = 20  # 6m
+        env.drawn_tile = new_drawn
+
+        h = env.hands
+        h[0].append(new_drawn)
+        env.hands = h
+
+        # Pick a different tile to discard (Tedashi)
+        # P0 hand has 10 (from previous if not claimed) or other initial tiles.
+        hand_tile = env.hands[0][0]
+        if hand_tile == new_drawn:
+            hand_tile = env.hands[0][1]
+
+        env.step({0: Action(ActionType.Discard, tile=hand_tile)})
+
+        # Verify
+        assert len(env.discard_from_hand[0]) == 2
+        assert env.discard_from_hand[0][-1] is True, "Should be Tedashi (True)"


### PR DESCRIPTION
Resolves https://github.com/smly/RiichiEnv/issues/65

This PR implements the tracking of discard types to distinguish between Tedashi (discard from hand) and Tsumogiri (discard immediately after draw). This feature is essential for downstream tasks like encoding state for neural networks, where knowing whether a discard was forced (Tsumogiri) or voluntary (Tedashi) provides critical information about the opponent's hand state.

## Changes

* Native (Rust):
  * Added `discard_from_hand: [Vec<bool>; 4]` to the `RiichiEnv` struct.
    * `True`: Discard was from hand (Tedashi).
    * `False`: Discard was the drawn tile (Tsumogiri).
* Updated `_perform_discard` to calculate and store the discard type based on the existing `is_tsumogiri` flag.
* Exposed `discard_from_hand` to Python via `#[pyo3(get)]`.

## Usage

The discard type history can be accessed directly from the environment:

```python
env = RiichiEnv()
# ... play game ...
# Check if the last discard of player 0 was Tedashi (True) or Tsumogiri (False)
is_tedashi = env.discard_from_hand[0][-1]
```
