### PR TITLE
feat: Expose core modules as `pub mod`

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -4,17 +4,17 @@ mod agari;
 mod hand_evaluator;
 mod score;
 mod tests;
-mod types;
+pub mod types;
 mod yaku;
 
-mod action;
+pub mod action;
 mod env;
-mod observation;
-mod parser;
+pub mod observation;
+pub mod parser;
 mod replay;
-mod rule;
+pub mod rule;
 mod shanten;
-mod state;
+pub mod state;
 pub mod win_projection;
 mod yaku_checker;
 


### PR DESCRIPTION
## Summary

  - Make `action`, `observation`, `parser`, `rule`, `state`, `types` modules `pub` in `lib.rs` so external Rust crates can import engine types
  - Internal modules (`env`, `replay`, `shanten`, `yaku_checker`, etc.) remain private
  - No change to Python bindings — `#[pymodule]` registration is independent of module visibility

  Closes #93
