### PR TITLE
fix: correct han-comment positions and wind yaku English names

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ The `yaku` field contains raw yaku IDs. Use `yaku_list()` to get detailed `Yaku`
 >>> for y in result.yaku_list():
 ...     print(y)
 Yaku(id=8, name='役牌 發', name_en='Yakuhai (hatsu)', tenhou_id=19, mjsoul_id=8)
-Yaku(id=11, name='場風牌', name_en='Yakuhai (wind of round)', tenhou_id=14, mjsoul_id=11)
-Yaku(id=10, name='自風牌', name_en='Yakuhai (wind of place)', tenhou_id=10, mjsoul_id=10)
+Yaku(id=11, name='場風牌', name_en='Yakuhai (round wind)', tenhou_id=14, mjsoul_id=11)
+Yaku(id=10, name='自風牌', name_en='Yakuhai (seat wind)', tenhou_id=10, mjsoul_id=10)
 Yaku(id=22, name='三暗刻', name_en='San Ankou', tenhou_id=29, mjsoul_id=22)
 ```
 

--- a/riichienv-core/src/yaku.rs
+++ b/riichienv-core/src/yaku.rs
@@ -43,15 +43,15 @@ const YAKU_TABLE: &[(u32, &str, &str, i32, i32)] = &[
     (7, "役牌 白", "Yakuhai (haku)", 18, 7),
     (8, "役牌 發", "Yakuhai (hatsu)", 19, 8),
     (9, "役牌 中", "Yakuhai (chun)", 20, 9),
-    (10, "自風牌", "Yakuhai (wind of place)", 10, 10), // tenhou_id=10 自風 東, tenhou_id=11 自風 南, tenhou_id=12 自風 西, tenhou_id=13 自風 北
-    (11, "場風牌", "Yakuhai (wind of round)", 14, 11), // tenhou_id=14 場風 東, tenhou_id=15 場風 南, tenhou_id=16 場風 西, tenhou_id=17 場風 北
+    (10, "自風牌", "Yakuhai (seat wind)", 10, 10), // tenhou_id=10 自風 東, tenhou_id=11 自風 南, tenhou_id=12 自風 西, tenhou_id=13 自風 北
+    (11, "場風牌", "Yakuhai (round wind)", 14, 11), // tenhou_id=14 場風 東, tenhou_id=15 場風 南, tenhou_id=16 場風 西, tenhou_id=17 場風 北
     (12, "断幺九", "Tanyao", 8, 12),
     (13, "一盃口", "Iipeiko", 9, 13),
     (14, "平和", "Pinfu", 7, 14),
+    // 2 Han
     (15, "混全帯幺九", "Chantai", 23, 15),
     (16, "一気通貫", "Ittsu", 24, 16),
     (17, "三色同順", "Sanshoku Doujun", 25, 17),
-    // 2 Han
     (18, "ダブル立直", "Double Riichi", 21, 18),
     (19, "三色同刻", "Sanshoku Doukou", 26, 19),
     (20, "三槓子", "San Kantsu", 27, 20),
@@ -60,9 +60,9 @@ const YAKU_TABLE: &[(u32, &str, &str, i32, i32)] = &[
     (23, "小三元", "Shou Sangen", 30, 23),
     (24, "混老頭", "Honroutou", 31, 24),
     (25, "七対子", "Chiitoitsu", 22, 25),
+    // 3 Han
     (26, "純全帯幺九", "Junchan", 33, 26),
     (27, "混一色", "Honitsu", 34, 27),
-    // 3 Han
     (28, "二盃口", "Ryanpeikou", 32, 28),
     // 6 Han
     (29, "清一色", "Chinitsu", 35, 29),

--- a/riichienv-ui/src/constants.ts
+++ b/riichienv-ui/src/constants.ts
@@ -1,6 +1,6 @@
 export const YAKU_MAP: { [key: number]: string } = {
     1: "Menzen Tsumo", 2: "Riichi", 3: "Chankan", 4: "Rinshan Kaihou", 5: "Haitei Raoyue", 6: "Houtei Raoyui",
-    7: "Haku", 8: "Hatsu", 9: "Chun", 10: "Jikaze (Seat Wind)", 11: "Bakaze (Prevalent Wind)",
+    7: "Haku", 8: "Hatsu", 9: "Chun", 10: "Jikaze (Seat Wind)", 11: "Bakaze (Round Wind)",
     12: "Tanyao", 13: "Iipeiko", 14: "Pinfu", 15: "Chanta", 16: "Ittsu", 17: "Sanshoku Doujun",
     18: "Double Riichi", 19: "Sanshoku Doukou", 20: "Sankantsu", 21: "Toitoi", 22: "San Ankou",
     23: "Shousangen", 24: "Honroutou", 25: "Chiitoitsu", 26: "Junchan", 27: "Honitsu",


### PR DESCRIPTION
- Fix misplaced `// 2 Han` and `// 3 Han` comments in `YAKU_TABLE` so they correctly delimit yaku groups
- Rename wind yaku English names to WRC-standard terminology: "wind of place" → "seat wind", "wind of round" → "round wind"
- Unify "Prevalent Wind" in riichienv-ui to "Round Wind" for consistency

### Note
- WRC uses "Round Wind" for 場風, while Mahjong Soul (雀魂) uses "Prevalent Wind". It may be useful to keep both string constants in the repository for different contexts, but that is out of scope for this PR.

Closes #104