### PR TITLE
fix(replay): preserve post-reach state for pending discard steps

### DIFF
--- a/riichienv-core/src/replay/mod.rs
+++ b/riichienv-core/src/replay/mod.rs
@@ -137,12 +137,13 @@ impl KyokuStepIterator {
                         staged_riichi = true;
                     }
                 }
-                let obs =
+                let obs_result =
                     slf.state
-                        .get_observation_for_replay(pid, &action, &format!("{:?}", action))?;
+                        .get_observation_for_replay(pid, &action, &format!("{:?}", action));
                 if staged_riichi {
                     slf.state.players[pid as usize].riichi_stage = false;
                 }
+                let obs = obs_result?;
 
                 let current_log_action = &actions[slf.idx];
                 slf.state.apply_log_action(current_log_action);
@@ -431,12 +432,13 @@ impl KyokuStepIterator3P {
                         staged_riichi = true;
                     }
                 }
-                let obs =
+                let obs_result =
                     slf.state
-                        .get_observation_for_replay(pid, &action, &format!("{:?}", action))?;
+                        .get_observation_for_replay(pid, &action, &format!("{:?}", action));
                 if staged_riichi {
                     slf.state.players[pid as usize].riichi_stage = false;
                 }
+                let obs = obs_result?;
 
                 let current_log_action = &actions[slf.idx];
                 slf.state.apply_log_action(current_log_action);

--- a/tests/test_mjai_replay.py
+++ b/tests/test_mjai_replay.py
@@ -146,3 +146,52 @@ def test_mjai_replay_3p_reach_discard_observation_is_not_duplicated_state(tmp_pa
     discard_legals = [a.action_type for a in discard_obs.legal_actions()]
     assert ActionType.Riichi in riichi_legals
     assert ActionType.Riichi not in discard_legals
+
+
+def test_mjai_replay_4p_reach_discard_observation_is_not_duplicated_state(tmp_path):
+    data = [
+        {"type": "start_game", "names": ["A", "B", "C", "D"], "id": "test_4p_reach"},
+        {
+            "type": "start_kyoku",
+            "bakaze": "E",
+            "kyoku": 1,
+            "honba": 0,
+            "kyoutaku": 0,
+            "oya": 0,
+            "scores": [25000, 25000, 25000, 25000],
+            "dora_marker": "1p",
+            "tehais": [
+                ["1p", "1p", "2p", "2p", "2p", "3p", "3p", "3p", "4p", "4p", "4p", "5z", "5z"],
+                ["1s", "1s", "1s", "2s", "2s", "2s", "3s", "3s", "3s", "4s", "4s", "4s", "6z"],
+                ["1z", "1z", "2z", "2z", "3z", "3z", "4z", "4z", "5z", "5z", "6z", "6z", "7z"],
+                ["5m", "5m", "6m", "6m", "7m", "7m", "8m", "8m", "9m", "9m", "1m", "1m", "2m"],
+            ],
+        },
+        {"type": "tsumo", "actor": 0, "pai": "1p"},
+        {"type": "reach", "actor": 0},
+        {"type": "dahai", "actor": 0, "pai": "1p", "tsumogiri": True},
+        {"type": "ryukyoku", "reason": "test"},
+        {"type": "end_kyoku"},
+        {"type": "end_game"},
+    ]
+
+    file_path = tmp_path / "test_4p_reach.jsonl"
+    with open(file_path, "w") as f:
+        for event in data:
+            f.write(json.dumps(event) + "\n")
+
+    replay = MjaiReplay.from_jsonl(str(file_path))
+    kyoku = list(replay.take_kyokus())[0]
+    steps = list(kyoku.steps(0, skip_single_action=False))
+
+    assert len(steps) >= 2
+    riichi_obs, riichi_act = steps[0]
+    discard_obs, discard_act = steps[1]
+
+    assert riichi_act.action_type == ActionType.Riichi
+    assert discard_act.action_type == ActionType.Discard
+
+    riichi_legals = [a.action_type for a in riichi_obs.legal_actions()]
+    discard_legals = [a.action_type for a in discard_obs.legal_actions()]
+    assert ActionType.Riichi in riichi_legals
+    assert ActionType.Riichi not in discard_legals


### PR DESCRIPTION
- Fix replay step generation for `reach + dahai` sequences in both 4-player and 3-player iterators.
- Previously, when a reach discard was split into two training steps (`Riichi` then pending `Discard`), the second step could be generated from an effectively pre-reach state.
- This produced inconsistent supervision for the same decision point (e.g. `Riichi` and `Discard` labels from equivalent observations), which can hurt offline BC learning.

Behavioral cloning models trained on 3-player logs were unable to learn Riichi declarations because the mask never flagged the correct index as legal.

<img width="696" height="200" alt="image" src="https://github.com/user-attachments/assets/1c2b3776-8509-468f-8674-b15d1085e8b8" />

