### PR TITLE
fix(replay): Fix MJAI replay riichi deposit accounting to preserve start-of-round liqibang

### DIFF
--- a/riichienv-core/src/replay/mjai_replay.rs
+++ b/riichienv-core/src/replay/mjai_replay.rs
@@ -423,9 +423,7 @@ impl MjaiReplay {
                 });
 
                 builder.first_discard[actor] = false;
-
                 if is_liqi {
-                    builder.liqibang += 1;
                     builder.liqi_flags[actor] = false;
                 }
             }


### PR DESCRIPTION
This PR fixes a replay parsing bug in `mjai_replay.rs` where `liqibang` (riichi sticks) was incorrectly mutated while processing in-round events.

The bug caused `LogKyoku.liqibang` to drift from its intended meaning (start-of-round kyotaku) to an in-round value after riichi declarations.  
As a result, replay-generated training samples could contain inconsistent state context for riichi decisions.

In `MjaiReplay::process_event`, when handling `MjaiEvent::Dahai` with `is_liqi == true`, the code did:

- clear `builder.liqi_flags[actor]` (expected), and
- increment `builder.liqibang` (unexpected for a start-of-round field).

`builder.liqibang` is later written into `LogKyoku.liqibang`, which should remain the round-start value from `start_kyoku.kyoutaku`.

## Changes
Removed the in-round mutation of `builder.liqibang`:

- deleted `builder.liqibang += 1` in the `is_liqi` branch,
- kept `builder.liqi_flags[actor] = false` unchanged.

This ensures `LogKyoku.liqibang` consistently represents start-of-round kyotaku.

## Why this is correct
- `liqibang` in `LogKyoku` is initialized from `start_kyoku` metadata.
- Round-start metadata must not be overwritten by per-action state transitions.
- In-round riichi accounting is already represented through action sequence / state progression during replay stepping.

## Impact
- Replay metadata becomes temporally consistent.
- Riichi-related training/evaluation data derived from replay avoids this specific context skew.
- No gameplay rule behavior is changed; this is a replay metadata correctness fix.