### PR TITLE
fix(ui): highlight only opponents' waits as dangerous tiles in hands

### DIFF
--- a/riichienv-ui/src/renderers/renderer_2d.ts
+++ b/riichienv-ui/src/renderers/renderer_2d.ts
@@ -154,9 +154,13 @@ export class Renderer2D implements IRenderer {
                 });
             }
         });
-        const dangerWaitsByPlayer = ownWaitsByPlayer.map((ownWaits) => {
-            const dangerWaits = new Set(activeWaits);
-            ownWaits.forEach((w) => dangerWaits.delete(w));
+        const dangerWaitsByPlayer = ownWaitsByPlayer.map((_, idx) => {
+            const dangerWaits = new Set<string>();
+            ownWaitsByPlayer.forEach((waits, otherIdx) => {
+                if (otherIdx !== idx) {
+                    waits.forEach((w) => dangerWaits.add(w));
+                }
+            });
             return dangerWaits;
         });
 

--- a/riichienv-ui/src/renderers/renderer_3d.ts
+++ b/riichienv-ui/src/renderers/renderer_3d.ts
@@ -217,9 +217,13 @@ export class Renderer3D implements IRenderer {
                 });
             }
         });
-        const dangerWaitsByPlayer = ownWaitsByPlayer.map((ownWaits) => {
-            const dangerWaits = new Set(activeWaits);
-            ownWaits.forEach((w) => dangerWaits.delete(w));
+        const dangerWaitsByPlayer = ownWaitsByPlayer.map((_, idx) => {
+            const dangerWaits = new Set<string>();
+            ownWaitsByPlayer.forEach((waits, otherIdx) => {
+                if (otherIdx !== idx) {
+                    waits.forEach((w) => dangerWaits.add(w));
+                }
+            });
             return dangerWaits;
         });
 


### PR DESCRIPTION
This PR refines dangerous-tile highlighting in `riichienv-ui`.

Previously, a player's hand tiles were highlighted in red if they matched **any** active wait on the table, including that player's own waits. This caused misleading highlights, because a tile matching your own wait is not "dangerous" from your perspective.

Now, hand highlighting excludes the player's own waits and only marks tiles that match other players' waits.