### PR TITLE
Fix MJAI replay start_kyoku wall initialization

### DIFF
--- a/riichienv-core/src/state/event_handler.rs
+++ b/riichienv-core/src/state/event_handler.rs
@@ -18,6 +18,7 @@ impl GameStateEventHandler for GameState {
         match event {
             MjaiEvent::StartKyoku {
                 bakaze,
+                kyoku,
                 honba,
                 kyoutaku,
                 scores,
@@ -26,12 +27,10 @@ impl GameStateEventHandler for GameState {
                 oya,
                 ..
             } => {
-                // Initialize round state from event
+                // Replay starts before the dealer's opening draw.
+                // Keep a placeholder wall sized to that pre-tsumo state.
                 self.honba = honba;
                 self.riichi_sticks = kyoutaku as u32;
-                self.players.iter_mut().enumerate().for_each(|(i, p)| {
-                    p.score = scores[i];
-                });
                 self.round_wind = match bakaze.as_str() {
                     "E" => Wind::East as u8,
                     "S" => Wind::South as u8,
@@ -40,9 +39,43 @@ impl GameStateEventHandler for GameState {
                     _ => Wind::East as u8,
                 };
                 self.oya = oya;
+                self.kyoku_idx = kyoku.saturating_sub(1);
+                self.current_player = self.oya;
+                self.turn_count = 0;
+                self.is_done = false;
+                self.needs_tsumo = true;
+                self.needs_initialize_next_round = false;
+                self.pending_oya_won = false;
+                self.pending_is_draw = false;
+                self.phase = Phase::WaitAct;
+                self.active_players.clear();
+                self.last_discard = None;
+                self.current_claims.clear();
+                self.pending_kan = None;
+                self.is_rinshan_flag = false;
+                self.is_first_turn = true;
+                self.riichi_pending_acceptance = None;
+                self.drawn_tile = None;
+                self.win_results.clear();
+                self.last_win_results.clear();
+                self.round_end_scores = None;
+                self.last_error = None;
+                self.is_after_kan = false;
+                self.riichi_sutehais = [None; 4];
+                self.last_tedashis = [None; 4];
+                self.wall.tiles = vec![0; 136 - 13 * 4];
                 self.wall.dora_indicators = vec![parse_mjai_tile(&dora_marker)];
+                self.wall.rinshan_draw_count = 0;
+                self.wall.pending_kan_dora_count = 0;
+                self.wall.wall_digest.clear();
+                self.wall.salt.clear();
 
-                // Set hands
+                for p in &mut self.players {
+                    p.reset_round();
+                }
+                self.players.iter_mut().enumerate().for_each(|(i, p)| {
+                    p.score = scores[i];
+                });
                 for (i, hand_strs) in tehais.iter().enumerate() {
                     let mut hand = Vec::new();
                     for tile_str in hand_strs {
@@ -51,18 +84,6 @@ impl GameStateEventHandler for GameState {
                     hand.sort();
                     self.players[i].hand = hand;
                 }
-
-                // Clear other state
-                for p in &mut self.players {
-                    p.discards.clear();
-                    p.melds.clear();
-                    p.riichi_declared = false;
-                    p.riichi_stage = false;
-                }
-                self.drawn_tile = None;
-                self.current_player = self.oya; // Oya starts
-                self.needs_tsumo = true;
-                self.is_done = false;
             }
             MjaiEvent::Tsumo { actor, pai } => {
                 let tile = parse_mjai_tile(&pai);

--- a/riichienv-core/src/state_3p/event_handler.rs
+++ b/riichienv-core/src/state_3p/event_handler.rs
@@ -19,6 +19,7 @@ impl GameState3PEventHandler for GameState3P {
         match event {
             MjaiEvent::StartKyoku {
                 bakaze,
+                kyoku,
                 honba,
                 kyoutaku,
                 scores,
@@ -27,11 +28,10 @@ impl GameState3PEventHandler for GameState3P {
                 oya,
                 ..
             } => {
+                // Replay starts before the dealer's opening draw.
+                // Keep a placeholder wall sized to that pre-tsumo state.
                 self.honba = honba;
                 self.riichi_sticks = kyoutaku as u32;
-                self.players.iter_mut().enumerate().for_each(|(i, p)| {
-                    p.score = scores[i];
-                });
                 self.round_wind = match bakaze.as_str() {
                     "E" => Wind::East as u8,
                     "S" => Wind::South as u8,
@@ -40,8 +40,43 @@ impl GameState3PEventHandler for GameState3P {
                     _ => Wind::East as u8,
                 };
                 self.oya = oya;
+                self.kyoku_idx = kyoku.saturating_sub(1);
+                self.current_player = self.oya;
+                self.turn_count = 0;
+                self.is_done = false;
+                self.needs_tsumo = true;
+                self.needs_initialize_next_round = false;
+                self.pending_oya_won = false;
+                self.pending_is_draw = false;
+                self.phase = Phase::WaitAct;
+                self.active_players.clear();
+                self.last_discard = None;
+                self.current_claims.clear();
+                self.pending_kan = None;
+                self.is_rinshan_flag = false;
+                self.is_first_turn = true;
+                self.riichi_pending_acceptance = None;
+                self.drawn_tile = None;
+                self.win_results.clear();
+                self.last_win_results.clear();
+                self.round_end_scores = None;
+                self.last_error = None;
+                self.is_after_kan = false;
+                self.riichi_sutehais = [None; 3];
+                self.last_tedashis = [None; 3];
+                self.wall.tiles = vec![0; 108 - 13 * 3];
                 self.wall.dora_indicators = vec![parse_mjai_tile(&dora_marker)];
+                self.wall.rinshan_draw_count = 0;
+                self.wall.pending_kan_dora_count = 0;
+                self.wall.wall_digest.clear();
+                self.wall.salt.clear();
 
+                for p in &mut self.players {
+                    p.reset_round();
+                }
+                self.players.iter_mut().enumerate().for_each(|(i, p)| {
+                    p.score = scores[i];
+                });
                 for (i, hand_strs) in tehais.iter().enumerate() {
                     let mut hand = Vec::new();
                     for tile_str in hand_strs {
@@ -50,17 +85,6 @@ impl GameState3PEventHandler for GameState3P {
                     hand.sort();
                     self.players[i].hand = hand;
                 }
-
-                for p in &mut self.players {
-                    p.discards.clear();
-                    p.melds.clear();
-                    p.riichi_declared = false;
-                    p.riichi_stage = false;
-                }
-                self.drawn_tile = None;
-                self.current_player = self.oya;
-                self.needs_tsumo = true;
-                self.is_done = false;
             }
             MjaiEvent::Tsumo { actor, pai } => {
                 let tile = parse_mjai_tile(&pai);

--- a/riichienv-core/src/tests.rs
+++ b/riichienv-core/src/tests.rs
@@ -573,6 +573,103 @@ mod unit_tests {
     }
 
     #[test]
+    fn test_apply_mjai_event_start_kyoku_resets_pre_tsumo_wall_4p() {
+        use crate::replay::MjaiEvent;
+
+        let mut state =
+            crate::state::GameState::new(2, true, None, 0, crate::rule::GameRule::default());
+
+        assert_eq!(
+            state.wall.tiles.len(),
+            83,
+            "fresh state should start post-tsumo"
+        );
+
+        state.apply_mjai_event(MjaiEvent::StartKyoku {
+            bakaze: "E".to_string(),
+            kyoku: 1,
+            honba: 0,
+            kyoutaku: 0,
+            oya: 0,
+            scores: vec![25000, 25000, 25000, 25000],
+            dora_marker: "1m".to_string(),
+            tehais: vec![
+                vec!["1m".to_string(); 13],
+                vec!["2m".to_string(); 13],
+                vec!["3m".to_string(); 13],
+                vec!["4m".to_string(); 13],
+            ],
+        });
+
+        assert_eq!(
+            state.wall.tiles.len(),
+            84,
+            "start_kyoku should rewind to pre-tsumo"
+        );
+        assert!(state.needs_tsumo, "dealer draw should still be pending");
+        assert!(state.drawn_tile.is_none(), "no tile should be drawn yet");
+
+        state.apply_mjai_event(MjaiEvent::Tsumo {
+            actor: 0,
+            pai: "5m".to_string(),
+        });
+
+        assert_eq!(
+            state.wall.tiles.len(),
+            83,
+            "first tsumo should consume exactly one tile"
+        );
+    }
+
+    #[test]
+    fn test_apply_mjai_event_start_kyoku_resets_pre_tsumo_wall_3p() {
+        use crate::replay::MjaiEvent;
+
+        let mut state =
+            crate::state_3p::GameState3P::new(5, true, None, 0, crate::rule::GameRule::default());
+
+        assert_eq!(
+            state.wall.tiles.len(),
+            68,
+            "fresh sanma state should start post-tsumo"
+        );
+
+        state.apply_mjai_event(MjaiEvent::StartKyoku {
+            bakaze: "E".to_string(),
+            kyoku: 1,
+            honba: 0,
+            kyoutaku: 0,
+            oya: 0,
+            scores: vec![35000, 35000, 35000],
+            dora_marker: "1p".to_string(),
+            tehais: vec![
+                vec!["1p".to_string(); 13],
+                vec!["2p".to_string(); 13],
+                vec!["3p".to_string(); 13],
+            ],
+        });
+
+        assert_eq!(
+            state.wall.tiles.len(),
+            69,
+            "sanma start_kyoku should rewind to pre-tsumo"
+        );
+        assert!(state.needs_tsumo, "dealer draw should still be pending");
+        assert!(state.drawn_tile.is_none(), "no tile should be drawn yet");
+
+        state.apply_mjai_event(MjaiEvent::Tsumo {
+            actor: 0,
+            pai: "4p".to_string(),
+        });
+
+        assert_eq!(
+            state.wall.tiles.len(),
+            68,
+            "first tsumo should consume exactly one tile"
+        );
+    }
+
+    #[test]
     fn test_reach_to_mjai_includes_actor() {
         use crate::action::{Action, ActionType};
 


### PR DESCRIPTION
## Summary

Fix an off-by-one bug in MJAI replay initialization.

`apply_mjai_event(start_kyoku)` was leaving replay state in the post-dealer-draw position, even though MJAI logs emit the dealer's first draw as a separate `tsumo` event. When that logged `tsumo` was applied, the wall became one tile too short for the rest of the round.

This mostly goes unnoticed, but it breaks legality checks near the end of the hand where rules depend on the remaining wall count. In the reproduced case, a real `chi` window was reconstructed as `Ron/Pass`, and `select_action_from_mjai(...)` failed to resolve the source event.

## What changed

- Reset 4-player MJAI replay state to the correct pre-dealer-draw wall length in `start_kyoku`
- Apply the same fix to 3-player replay state
- Reset round-scoped replay fields during `start_kyoku` so replay starts from a clean round state
- Add regression tests covering the pre-tsumo wall length in both 4p and 3p

## Why this fixes the bug

For MJAI replay, the correct sequence is:

- `start_kyoku` -> wall is still pre-dealer-draw
- first `tsumo` -> consume exactly one tile

Before this patch, replay effectively started one step too late, so the first logged `tsumo` consumed an extra tile and shifted the rest of the round out of sync.

## Repro

Using `2024010109gm-00a9-0000-1fe4306c.json`:

- before this patch, after player 2 discarded `9s`, seat 3 saw `Ron/Pass`
- after this patch, seat 3 correctly sees `Chi/Pass`
- `select_action_from_mjai({"type":"chi","actor":3,"target":2,"pai":"9s","consumed":["7s","8s"]})` now resolves successfully

## Testing

- `cargo test -q apply_mjai_event_start_kyoku -- --nocapture`
- `cargo test -q test_apply_mjai_event_honor_and_red_tiles -- --nocapture`

Manual verification:

- converted the repro paipu to MJAI events
- replayed the failing round via `apply_mjai_event(...)`
- confirmed the response window now matches the source `chi`
