### PR TITLE
fix: Fix missing kita action mapping in 3P observation Python bridge

### DIFF
--- a/riichienv-core/src/observation_3p/python.rs
+++ b/riichienv-core/src/observation_3p/python.rs
@@ -166,6 +166,7 @@ impl Observation3P {
             "kakan" => Some(crate::action::ActionType::Kakan),
             "daiminkan" => Some(crate::action::ActionType::Daiminkan),
             "ankan" => Some(crate::action::ActionType::Ankan),
+            "kita" => Some(crate::action::ActionType::Kita),
             "reach" => Some(crate::action::ActionType::Riichi),
             "hora" => None,
             "ryukyoku" => Some(crate::action::ActionType::KyushuKyuhai),


### PR DESCRIPTION
Add missing `"kita"` match arm in `select_action_from_mjai` for 3P observation.

Fixes #163

Thanks for the bug report! @shinkuan, @Apricot-S