### PR TITLE
fix: add missing Kita variant to ActionType and adopt SCREAMING_SNAKE_CASE

### DIFF
--- a/riichienv-core/src/action.rs
+++ b/riichienv-core/src/action.rs
@@ -42,7 +42,13 @@ impl Phase {
 
 #[cfg_attr(
     feature = "python",
-    pyclass(module = "riichienv._riichienv", eq, eq_int, from_py_object)
+    pyclass(
+        module = "riichienv._riichienv",
+        eq,
+        eq_int,
+        from_py_object,
+        rename_all = "SCREAMING_SNAKE_CASE"
+    )
 )]
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/riichienv/_riichienv.pyi
+++ b/src/riichienv/_riichienv.pyi
@@ -53,29 +53,31 @@ class Phase(IntEnum):
     WaitResponse = 1
 
 class ActionType:
-    Discard: ActionType
-    Chi: ActionType
-    Pon: ActionType
-    Daiminkan: ActionType
-    Ankan: ActionType
-    Kakan: ActionType
-    Riichi: ActionType
-    Tsumo: ActionType
-    Ron: ActionType
-    Pass: ActionType
-    KyushuKyuhai: ActionType
-    # Upper case aliases
     DISCARD: ActionType
     CHI: ActionType
     PON: ActionType
     DAIMINKAN: ActionType
-    ANKAN: ActionType
-    KAKAN: ActionType
+    RON: ActionType
     RIICHI: ActionType
     TSUMO: ActionType
-    RON: ActionType
     PASS: ActionType
+    ANKAN: ActionType
+    KAKAN: ActionType
     KYUSHU_KYUHAI: ActionType
+    KITA: ActionType
+    # PascalCase aliases (deprecated)
+    Discard: ActionType
+    Chi: ActionType
+    Pon: ActionType
+    Daiminkan: ActionType
+    Ron: ActionType
+    Riichi: ActionType
+    Tsumo: ActionType
+    Pass: ActionType
+    Ankan: ActionType
+    Kakan: ActionType
+    KyushuKyuhai: ActionType
+    Kita: ActionType
     def __int__(self) -> int: ...
 
 class Action:
@@ -95,7 +97,7 @@ class Action3P:
 
     def __init__(
         self,
-        type: ActionType = ActionType.Pass,  # noqa: A002
+        type: ActionType = ActionType.PASS,  # noqa: A002
         tile: int | None = None,
         consume_tiles: list[int] = [],
         actor: int | None = None,

--- a/src/riichienv/action.py
+++ b/src/riichienv/action.py
@@ -2,15 +2,16 @@ from ._riichienv import Action, Action3P, ActionType
 
 __all__ = ["Action", "Action3P", "ActionType"]
 
-# Uppercase aliases for backward compatibility
-ActionType.DISCARD = ActionType.Discard
-ActionType.CHI = ActionType.Chi
-ActionType.PON = ActionType.Pon
-ActionType.DAIMINKAN = ActionType.Daiminkan
-ActionType.RON = ActionType.Ron
-ActionType.RIICHI = ActionType.Riichi
-ActionType.TSUMO = ActionType.Tsumo
-ActionType.PASS = ActionType.Pass
-ActionType.ANKAN = ActionType.Ankan
-ActionType.KAKAN = ActionType.Kakan
-ActionType.KYUSHU_KYUHAI = ActionType.KyushuKyuhai
+# PascalCase aliases for backward compatibility (deprecated)
+ActionType.Discard = ActionType.DISCARD
+ActionType.Chi = ActionType.CHI
+ActionType.Pon = ActionType.PON
+ActionType.Daiminkan = ActionType.DAIMINKAN
+ActionType.Ron = ActionType.RON
+ActionType.Riichi = ActionType.RIICHI
+ActionType.Tsumo = ActionType.TSUMO
+ActionType.Pass = ActionType.PASS
+ActionType.Ankan = ActionType.ANKAN
+ActionType.Kakan = ActionType.KAKAN
+ActionType.KyushuKyuhai = ActionType.KYUSHU_KYUHAI
+ActionType.Kita = ActionType.KITA

--- a/tests/env/actions/test_action_to_mjai.py
+++ b/tests/env/actions/test_action_to_mjai.py
@@ -5,27 +5,27 @@ from riichienv import Action, ActionType, Observation
 
 class TestActionToMjaiFormat:
     def test_action_to_mjai_dahai(self):
-        act = Action(ActionType.Discard, tile=53)
+        act = Action(ActionType.DISCARD, tile=53)
         mjai = act.to_mjai()
         assert json.loads(mjai) == {"type": "dahai", "pai": "5p"}
 
     def test_action_to_mjai_chi(self):
         # Chi 5p with 4p,6p consumed
         # 5p (53), 4p (49), 6p (57)
-        act = Action(ActionType.Chi, tile=53, consume_tiles=[49, 57])
+        act = Action(ActionType.CHI, tile=53, consume_tiles=[49, 57])
         mjai = act.to_mjai()
         expected = {"type": "chi", "pai": "5p", "consumed": ["4p", "6p"]}
         assert json.loads(mjai) == expected
 
     def test_action_to_mjai_reach(self):
-        act = Action(ActionType.Riichi)
+        act = Action(ActionType.RIICHI)
         mjai = act.to_mjai()
         assert json.loads(mjai) == {"type": "reach"}
 
     def test_select_action_from_mjai(self):
         legal_actions = [
-            Action(ActionType.Discard, tile=53),  # 5p
-            Action(ActionType.Riichi),
+            Action(ActionType.DISCARD, tile=53),  # 5p
+            Action(ActionType.RIICHI),
         ]
 
         player_id = 0
@@ -66,13 +66,13 @@ class TestActionToMjaiFormat:
         mjai_dict = {"type": "dahai", "pai": "5p"}
         selected = obs.select_action_from_mjai(mjai_dict)
         assert selected is not None
-        assert selected.action_type == ActionType.Discard
+        assert selected.action_type == ActionType.DISCARD
         assert selected.tile == 53
 
         # Riichi
         selected = obs.select_action_from_mjai({"type": "reach"})
         assert selected is not None
-        assert selected.action_type == ActionType.Riichi
+        assert selected.action_type == ActionType.RIICHI
 
         # Non-existent action
         selected = obs.select_action_from_mjai({"type": "dahai", "pai": "1z"})
@@ -82,5 +82,5 @@ class TestActionToMjaiFormat:
         mjai_loose = {"type": "dahai", "pai": "5p", "tsumogiri": True, "meta": {"foo": "bar"}}
         selected = obs.select_action_from_mjai(mjai_loose)
         assert selected is not None
-        assert selected.action_type == ActionType.Discard
+        assert selected.action_type == ActionType.DISCARD
         assert selected.tile == 53

--- a/tests/env/actions/test_daiminkan_rinshan_draw.py
+++ b/tests/env/actions/test_daiminkan_rinshan_draw.py
@@ -21,7 +21,7 @@ class TestDaiminkan:
             phase=Phase.WaitAct,
             drawn_tile=75,  # 2s (4th copy). P1 has 72,73,74.
         )
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=75)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=75)})
         assert 1 in obs_dict, "Player 1 should be active"
         assert env.phase == Phase.WaitResponse, f"Phase should be WaitResponse, got {env.phase}"
 

--- a/tests/env/actions/test_kakan.py
+++ b/tests/env/actions/test_kakan.py
@@ -33,7 +33,7 @@ class TestKakan:
         player_id = 0
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
-        assert any([a.action_type == ActionType.Kakan for a in obs.legal_actions()]), (
+        assert any([a.action_type == ActionType.KAKAN for a in obs.legal_actions()]), (
             "Should have KAKAN action available"
         )
 
@@ -61,11 +61,11 @@ class TestKakan:
         player_id = 0
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
-        assert any([a.action_type == ActionType.Kakan for a in obs.legal_actions()]), (
+        assert any([a.action_type == ActionType.KAKAN for a in obs.legal_actions()]), (
             "Should have KAKAN action available"
         )
 
-        kakan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Kakan]
+        kakan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.KAKAN]
         assert len(kakan_actions) > 0, "Should have KAKAN action available"
 
         k_action = kakan_actions[0]

--- a/tests/env/actions/test_meld_aka.py
+++ b/tests/env/actions/test_meld_aka.py
@@ -22,10 +22,10 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=17,
         )
-        env.step({0: Action(ActionType.Discard, 17, [])})
+        env.step({0: Action(ActionType.DISCARD, 17, [])})
         assert env.phase == Phase.WaitResponse
         # 3m(8), 4m (12), 5m(17)
-        env.step({1: Action(ActionType.Chi, tile=17, consume_tiles=[8, 12])})
+        env.step({1: Action(ActionType.CHI, tile=17, consume_tiles=[8, 12])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "chi"
         assert env.active_players == [1]
@@ -43,10 +43,10 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=16,
         )
-        env.step({0: Action(ActionType.Discard, 16, [])})
+        env.step({0: Action(ActionType.DISCARD, 16, [])})
         assert env.phase == Phase.WaitResponse
         # 3m(8), 4m (12), 0m(16)
-        env.step({1: Action(ActionType.Chi, tile=16, consume_tiles=[8, 12])})
+        env.step({1: Action(ActionType.CHI, tile=16, consume_tiles=[8, 12])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "chi"
         assert env.active_players == [1]
@@ -64,10 +64,10 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=17,
         )
-        env.step({0: Action(ActionType.Discard, 17, [])})
+        env.step({0: Action(ActionType.DISCARD, 17, [])})
         assert env.phase == Phase.WaitResponse
         # 4m (12), 5m(17), 6m (20)
-        env.step({1: Action(ActionType.Chi, tile=17, consume_tiles=[12, 20])})
+        env.step({1: Action(ActionType.CHI, tile=17, consume_tiles=[12, 20])})
         assert env.phase == Phase.WaitAct
         assert env.active_players == [1]
         assert env.mjai_log[-1]["type"] == "chi"
@@ -85,10 +85,10 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=16,
         )
-        env.step({0: Action(ActionType.Discard, 16, [])})
+        env.step({0: Action(ActionType.DISCARD, 16, [])})
         assert env.phase == Phase.WaitResponse
         # 4m (12), 0m(16), 6m (20)
-        env.step({1: Action(ActionType.Chi, tile=16, consume_tiles=[12, 20])})
+        env.step({1: Action(ActionType.CHI, tile=16, consume_tiles=[12, 20])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "chi"
         assert env.active_players == [1]
@@ -106,10 +106,10 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=17,
         )
-        env.step({0: Action(ActionType.Discard, 17, [])})
+        env.step({0: Action(ActionType.DISCARD, 17, [])})
         assert env.phase == Phase.WaitResponse
         # 4m (12), 5m(17), 6m (20)
-        env.step({1: Action(ActionType.Chi, tile=17, consume_tiles=[20, 24])})
+        env.step({1: Action(ActionType.CHI, tile=17, consume_tiles=[20, 24])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "chi"
         assert env.active_players == [1]
@@ -127,12 +127,12 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=16,
         )
-        env.step({0: Action(ActionType.Discard, 16, [])})
+        env.step({0: Action(ActionType.DISCARD, 16, [])})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [1]
         assert 20 in env.hands[1]  # 6m
         assert 24 in env.hands[1]  # 7m (first 7m)
-        env.step({1: Action(ActionType.Chi, tile=16, consume_tiles=[20, 24])})
+        env.step({1: Action(ActionType.CHI, tile=16, consume_tiles=[20, 24])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "chi"
         assert env.active_players == [1]
@@ -150,14 +150,14 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=16,
         )
-        env.step({0: Action(ActionType.Discard, 16, [])})
+        env.step({0: Action(ActionType.DISCARD, 16, [])})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [1]
         assert 20 in env.hands[1]  # 6m
         assert 25 in env.hands[1]  # 7m (second 7m)
         assert cvt.tid_to_mpsz(25) == "7m"
         # NOTE: Verify relaxed check for chi
-        env.step({1: Action(ActionType.Chi, tile=16, consume_tiles=[20, 25])})
+        env.step({1: Action(ActionType.CHI, tile=16, consume_tiles=[20, 25])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "chi"
         assert env.active_players == [1]
@@ -175,12 +175,12 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=16,
         )
-        env.step({0: Action(ActionType.Discard, 16, [])})
+        env.step({0: Action(ActionType.DISCARD, 16, [])})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [1]
         assert 17 in env.hands[1]
         assert 18 in env.hands[1]
-        env.step({1: Action(ActionType.Pon, tile=16, consume_tiles=[17, 18])})
+        env.step({1: Action(ActionType.PON, tile=16, consume_tiles=[17, 18])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "pon"
         assert env.active_players == [1]
@@ -198,12 +198,12 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=19,
         )
-        env.step({0: Action(ActionType.Discard, 19, [])})
+        env.step({0: Action(ActionType.DISCARD, 19, [])})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [1]
         assert 17 in env.hands[1]
         assert 18 in env.hands[1]
-        env.step({1: Action(ActionType.Pon, tile=19, consume_tiles=[17, 18])})
+        env.step({1: Action(ActionType.PON, tile=19, consume_tiles=[17, 18])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "pon"
         assert env.active_players == [1]
@@ -221,12 +221,12 @@ class TestMeldWithAkaDora:
             active_players=[0],
             drawn_tile=18,
         )
-        env.step({0: Action(ActionType.Discard, 18, [])})
+        env.step({0: Action(ActionType.DISCARD, 18, [])})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [1]
         assert 16 in env.hands[1]
         assert 17 in env.hands[1]
-        env.step({1: Action(ActionType.Pon, tile=18, consume_tiles=[16, 17])})
+        env.step({1: Action(ActionType.PON, tile=18, consume_tiles=[16, 17])})
         assert env.phase == Phase.WaitAct
         assert env.mjai_log[-1]["type"] == "pon"
         assert env.active_players == [1]

--- a/tests/env/actions/test_relaxed_red5.py
+++ b/tests/env/actions/test_relaxed_red5.py
@@ -22,7 +22,7 @@ class TestRelaxedRed5Check:
         )
 
         # Player 3 discards 3m
-        obs = env.step({3: Action(ActionType.Discard, tile=8)})
+        obs = env.step({3: Action(ActionType.DISCARD, tile=8)})
 
         if 0 in obs:
             # P0 should have legal actions.
@@ -30,7 +30,7 @@ class TestRelaxedRed5Check:
             print(f"DEBUG: P0 Legal Action Types: {legal_types}")
 
         # Player 0 Chi: [0m, 4m, 3m] -> consume [16, 12]
-        action = Action(ActionType.Chi, tile=8, consume_tiles=[16, 12])
+        action = Action(ActionType.CHI, tile=8, consume_tiles=[16, 12])
 
         obs = env.step({0: action})
 
@@ -43,10 +43,10 @@ class TestRelaxedRed5Check:
         """
         hand = [16, 12] + [108, 109, 110, 112, 113, 114, 116, 117, 118, 120, 121]
         env = helper_setup_env(hands=[hand, [], [], []], current_player=3, drawn_tile=8, active_players=[3], phase=0)
-        env.step({3: Action(ActionType.Discard, tile=8)})
+        env.step({3: Action(ActionType.DISCARD, tile=8)})
 
         # Action specifies Normal 5m (20) but we have Red 5m (16).
-        action = Action(ActionType.Chi, tile=8, consume_tiles=[20, 12])
+        action = Action(ActionType.CHI, tile=8, consume_tiles=[20, 12])
 
         env.step({0: action})
 
@@ -63,9 +63,9 @@ class TestRelaxedRed5Check:
         # Relax check: 18 matches 17 (Same type, Non-Red).
         hand = [17, 12] + [108, 109, 110, 112, 113, 114, 116, 117, 118, 120, 121]
         env = helper_setup_env(hands=[hand, [], [], []], current_player=3, drawn_tile=8, active_players=[3], phase=0)
-        env.step({3: Action(ActionType.Discard, tile=8)})
+        env.step({3: Action(ActionType.DISCARD, tile=8)})
 
-        action = Action(ActionType.Chi, tile=8, consume_tiles=[18, 12])
+        action = Action(ActionType.CHI, tile=8, consume_tiles=[18, 12])
         env.step({0: action})
         assert len(env.melds[0]) == 0, "Strict hand check should prevent using 18 when holding 17"
 
@@ -73,9 +73,9 @@ class TestRelaxedRed5Check:
         # Case 2: Hand=[17, 12], Action=[17, 12]. Should PASS.
         hand = [17, 12] + [108, 109, 110, 112, 113, 114, 116, 117, 118, 120, 121]
         env = helper_setup_env(hands=[hand, [], [], []], current_player=3, drawn_tile=8, active_players=[3], phase=0)
-        env.step({3: Action(ActionType.Discard, tile=8)})
+        env.step({3: Action(ActionType.DISCARD, tile=8)})
 
-        action = Action(ActionType.Chi, tile=8, consume_tiles=[17, 12])
+        action = Action(ActionType.CHI, tile=8, consume_tiles=[17, 12])
         env.step({0: action})
         assert len(env.melds[0]) > 0
         assert 17 in env.melds[0][0].tiles

--- a/tests/env/actions/test_riichi_autoplay_pass.py
+++ b/tests/env/actions/test_riichi_autoplay_pass.py
@@ -23,12 +23,12 @@ class TestRiichiAutoPlayAfterPass:
             drawn_tile=parse_tile("5p"),
         )
         env.get_observations([0])
-        obs = env.step({0: Action(ActionType.Riichi)})
+        obs = env.step({0: Action(ActionType.RIICHI)})
         legal_actions = obs[0].legal_actions()
 
         # All legal actions should be Discard
         legal_types = [a.action_type for a in legal_actions]
-        assert all(a.action_type == ActionType.Discard for a in legal_actions), (
+        assert all(a.action_type == ActionType.DISCARD for a in legal_actions), (
             f"Non-discard action found: {legal_types}"
         )
         # "5p" and "1z" should be among the tiles to discard.

--- a/tests/env/actions/test_riichi_no_claim.py
+++ b/tests/env/actions/test_riichi_no_claim.py
@@ -25,7 +25,7 @@ class TestRiichiNoClaim:
             phase=Phase.WaitAct,
             drawn_tile=2,
         )
-        env.step({3: Action(ActionType.Discard, 2)})
+        env.step({3: Action(ActionType.DISCARD, 2)})
 
         # Turned into P0's turn implies PON opportunity was skipped
         assert env.phase == Phase.WaitAct and env.active_players == [0]
@@ -45,11 +45,11 @@ class TestRiichiNoClaim:
             phase=Phase.WaitAct,
             drawn_tile=11,
         )
-        obs = env.step({3: Action(ActionType.Discard, 11)})
+        obs = env.step({3: Action(ActionType.DISCARD, 11)})
         assert env.phase == Phase.WaitResponse and env.active_players == [0]
         actions = obs[0].legal_actions()
-        assert not any(ac.action_type == ActionType.Chi for ac in actions)
-        assert any(ac.action_type == ActionType.Ron for ac in actions)
+        assert not any(ac.action_type == ActionType.CHI for ac in actions)
+        assert any(ac.action_type == ActionType.RON for ac in actions)
 
     @pytest.mark.skip(reason="Too complex to test")
     def test_riichi_rule_violation(self) -> None:

--- a/tests/env/actions/test_riichi_pass.py
+++ b/tests/env/actions/test_riichi_pass.py
@@ -32,16 +32,16 @@ class TestRiichiPassAction:
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
 
-        # expected legal actions => [ActionType.Discard, ActionType.Tsumo]
-        assert ActionType.Discard in [a.action_type for a in obs.legal_actions()], (
+        # expected legal actions => [ActionType.DISCARD, ActionType.TSUMO]
+        assert ActionType.DISCARD in [a.action_type for a in obs.legal_actions()], (
             "DISCARD should be available in Riichi"
         )
-        assert ActionType.Pass not in [a.action_type for a in obs.legal_actions()], (
+        assert ActionType.PASS not in [a.action_type for a in obs.legal_actions()], (
             "PASS should NOT be available in Riichi (WaitAct)"
         )
-        assert ActionType.Tsumo in [a.action_type for a in obs.legal_actions()], "Tsumo should be available in Riichi"
+        assert ActionType.TSUMO in [a.action_type for a in obs.legal_actions()], "Tsumo should be available in Riichi"
 
-        act = Action(ActionType.Discard, 10)
+        act = Action(ActionType.DISCARD, 10)
         obs = env.step({player_id: act})
         assert 1 in obs, (
             f"Should be player 1's turn. Keys: {list(obs.keys())}. Phase: {env.phase}, Active: {env.active_players}"

--- a/tests/env/agari/test_chankan.py
+++ b/tests/env/agari/test_chankan.py
@@ -30,7 +30,7 @@ class TestChankan:
 
         # Player 0 performs Kakan
         # Pon tiles are [0, 1, 2]
-        kakan_action = Action(ActionType.Kakan, tile=3, consume_tiles=[0, 1, 2])
+        kakan_action = Action(ActionType.KAKAN, tile=3, consume_tiles=[0, 1, 2])
         obs_dict = env.step({0: kakan_action})
 
         # Env should transition to WaitResponse for Player 1
@@ -41,7 +41,7 @@ class TestChankan:
 
         # Player 1 should have Ron action
         legal_actions = obs_dict[1].legal_actions()
-        ron_actions = [a for a in legal_actions if a.action_type == ActionType.Ron]
+        ron_actions = [a for a in legal_actions if a.action_type == ActionType.RON]
         assert len(ron_actions) > 0, f"No Ron actions found. Legal actions: {legal_actions}"
         assert ron_actions[0].tile == 3
 
@@ -84,11 +84,11 @@ class TestChankan:
         env.phase = Phase.WaitAct
         env.active_players = [0]
 
-        kakan_action = Action(ActionType.Kakan, tile=3, consume_tiles=[0, 1, 2])
+        kakan_action = Action(ActionType.KAKAN, tile=3, consume_tiles=[0, 1, 2])
         env.step({0: kakan_action})
 
         # Player 1 performs PASS
-        env.step({1: Action(ActionType.Pass)})
+        env.step({1: Action(ActionType.PASS)})
 
         # Env should proceed with KAKAN execution and Rinshan Draw for Player 0
         assert env.phase == Phase.WaitAct
@@ -128,7 +128,7 @@ class TestChankan:
         env.active_players = [0]
 
         # Use tile 111 for Ankan
-        ankan_action = Action(ActionType.Ankan, tile=111, consume_tiles=[108, 109, 110, 111])
+        ankan_action = Action(ActionType.ANKAN, tile=111, consume_tiles=[108, 109, 110, 111])
         obs_dict = env.step({0: ankan_action})
 
         # Should transition to WaitResponse for Player 1
@@ -136,7 +136,7 @@ class TestChankan:
         assert 1 in env.active_players
 
         legal_actions = obs_dict[1].legal_actions()
-        ron_actions = [a for a in legal_actions if a.action_type == ActionType.Ron]
+        ron_actions = [a for a in legal_actions if a.action_type == ActionType.RON]
         assert len(ron_actions) > 0
         assert ron_actions[0].tile == 111
 
@@ -176,7 +176,7 @@ class TestChankan:
         env.active_players = [0]
 
         # Use tile 111 for Ankan
-        ankan_action = Action(ActionType.Ankan, tile=111, consume_tiles=[108, 109, 110, 111])
+        ankan_action = Action(ActionType.ANKAN, tile=111, consume_tiles=[108, 109, 110, 111])
         env.step({0: ankan_action})
 
         assert env.phase == Phase.WaitAct
@@ -208,7 +208,7 @@ class TestChankan:
         env.phase = Phase.WaitAct
         env.active_players = [0]
 
-        ankan_action = Action(ActionType.Ankan, tile=111, consume_tiles=[108, 109, 110, 111])
+        ankan_action = Action(ActionType.ANKAN, tile=111, consume_tiles=[108, 109, 110, 111])
         env.step({0: ankan_action})
 
         # Should NOT transition to WaitResponse. Should immediately execute ANKAN.
@@ -237,7 +237,7 @@ class TestChankan:
 
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        ankan = [a for a in legals if a.action_type == ActionType.Ankan]
+        ankan = [a for a in legals if a.action_type == ActionType.ANKAN]
         assert len(ankan) > 0
         assert ankan[0].tile in [0, 1, 2, 3]
         assert sorted(ankan[0].consume_tiles) == [0, 1, 2, 3]
@@ -262,7 +262,7 @@ class TestChankan:
 
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        ankan = [a for a in legals if a.action_type == ActionType.Ankan]
+        ankan = [a for a in legals if a.action_type == ActionType.ANKAN]
         assert len(ankan) > 0
         assert ankan[0].tile == 0  # In Riichi, must be the drawn tile (or equivalent type)
         assert sorted(ankan[0].consume_tiles) == [0, 1, 2, 3]
@@ -300,12 +300,12 @@ class TestChankan:
 
         # 1. P2 discards 7p (63). (P0 has 61, 62).
         # Wait, P2 discard 7p (63). P0 (61, 62) should have Pon.
-        obs = env.step({2: Action(ActionType.Discard, 63)})
+        obs = env.step({2: Action(ActionType.DISCARD, 63)})
         assert 0 in obs
 
         # 2. All pass.
         # Strict turn validation requires only active players to act.
-        env.step({pid: Action(ActionType.Pass) for pid in obs.keys()})
+        env.step({pid: Action(ActionType.PASS) for pid in obs.keys()})
         assert env.current_player == 3
 
         # 3. P3 draws 6p (59) and kakans.
@@ -314,8 +314,8 @@ class TestChankan:
         h3[3] = [59]
         env.hands = h3
 
-        obs = env.step({3: Action(ActionType.Kakan, 59, [56, 57, 58])})
+        obs = env.step({3: Action(ActionType.KAKAN, 59, [56, 57, 58])})
 
         assert 0 in obs, f"P0 should be active for Chankan. Phase: {env.phase}, Active: {env.active_players}"
         action_types = [a.action_type for a in obs[0].legal_actions()]
-        assert ActionType.Ron in action_types, f"P0 should have Ron offered. Actions: {action_types}"
+        assert ActionType.RON in action_types, f"P0 should have Ron offered. Actions: {action_types}"

--- a/tests/env/agari/test_pao.py
+++ b/tests/env/agari/test_pao.py
@@ -33,14 +33,14 @@ class TestPao:
         )
 
         # P1 discards 3rd Red Dragon (134)
-        env.step({1: Action(ActionType.Discard, tile=134)})
+        env.step({1: Action(ActionType.DISCARD, tile=134)})
 
         # P0 calls Pon
-        env.step({0: Action(ActionType.Pon, tile=134, consume_tiles=[132, 133])})
+        env.step({0: Action(ActionType.PON, tile=134, consume_tiles=[132, 133])})
 
         # Verify Pao is established (Daisangen Yaku ID 37)
         assert env.pao[0].get(37) == 1
-        env.step({0: Action(ActionType.Discard, tile=4)})
+        env.step({0: Action(ActionType.DISCARD, tile=4)})
 
         # P0 draws completing tile for 2m pair (6 is 2m)
         env.current_player = 0
@@ -53,7 +53,7 @@ class TestPao:
         env.hands = h
 
         # Tsumo
-        env.step({0: Action(ActionType.Tsumo)})
+        env.step({0: Action(ActionType.TSUMO)})
 
         # Verify scoring
         agari_res = env.win_results[0]
@@ -111,48 +111,48 @@ class TestPao:
         )
 
         # P1 discards 134
-        env.step({1: Action(ActionType.Discard, tile=134)})
+        env.step({1: Action(ActionType.DISCARD, tile=134)})
 
         # P0 Pons
-        env.step({0: Action(ActionType.Pon, tile=134, consume_tiles=[132, 133])})
+        env.step({0: Action(ActionType.PON, tile=134, consume_tiles=[132, 133])})
 
         assert env.pao[0].get(37) == 1
 
         # P0 Discards 120 (North). Hand: 0,1,2 (1m), 36(1p). Tanki wait on 1p.
-        env.step({0: Action(ActionType.Discard, tile=120)})
+        env.step({0: Action(ActionType.DISCARD, tile=120)})
 
         # To clear "Doujun Furiten", we must cycle a full turn so P0 draws again.
 
         # P1 Turn
         env.step({})
-        env.step({1: Action(ActionType.Discard, tile=100)})
+        env.step({1: Action(ActionType.DISCARD, tile=100)})
 
         # P2 Turn
         env.step({})
-        env.step({2: Action(ActionType.Discard, tile=101)})
+        env.step({2: Action(ActionType.DISCARD, tile=101)})
 
         # P3 Turn
         env.step({})
-        env.step({3: Action(ActionType.Discard, tile=102)})
+        env.step({3: Action(ActionType.DISCARD, tile=102)})
 
         # P0 Turn - Draws and Discards (clears Furiten)
         env.step({})
-        env.step({0: Action(ActionType.Discard, tile=103)})
+        env.step({0: Action(ActionType.DISCARD, tile=103)})
 
         # P1 Turn
         env.step({})
-        env.step({1: Action(ActionType.Discard, tile=10)})
+        env.step({1: Action(ActionType.DISCARD, tile=10)})
 
         # P2 Turn - Discards Winning Tile 37
         env.step({})
-        env.step({2: Action(ActionType.Discard, tile=37)})
+        env.step({2: Action(ActionType.DISCARD, tile=37)})
 
         # P0 Ron
         obs = env.get_obs_py([0])[0]
-        ron_available = any(a.action_type == ActionType.Ron for a in obs.legal_actions())
+        ron_available = any(a.action_type == ActionType.RON for a in obs.legal_actions())
         assert ron_available, f"Ron not available! Legal: {obs.legal_actions()}"
 
-        env.step({0: Action(ActionType.Ron, tile=37)})
+        env.step({0: Action(ActionType.RON, tile=37)})
         assert env.is_done
 
         # Ko Yakuman Ron: 32000 points.

--- a/tests/env/agari/test_pao_honba.py
+++ b/tests/env/agari/test_pao_honba.py
@@ -39,9 +39,9 @@ class TestPaoHonba:
         env.phase = Phase.WaitResponse
         env.last_discard = (0, 134)  # 3rd Red
         env.active_players = [3]
-        env.current_claims = {3: [Action(ActionType.Pon, tile=134, consume_tiles=[132, 133])]}
+        env.current_claims = {3: [Action(ActionType.PON, tile=134, consume_tiles=[132, 133])]}
 
-        env.step({3: Action(ActionType.Pon, tile=134, consume_tiles=[132, 133])})
+        env.step({3: Action(ActionType.PON, tile=134, consume_tiles=[132, 133])})
 
         assert env.pao[3].get(37) == 0  # Seat 3 won, Seat 0 responsible
 
@@ -49,14 +49,14 @@ class TestPaoHonba:
         # After PON, P3 must discard. Hand: [0, 1, 2, 4, 99].
         # Discard 99. Hand: [0, 1, 2, 4]. Triplet 1m + Single 2m. Wait on 2m.
         # Total tiles: 4 (hand) + 9 (3 melds) = 13.
-        env.step({3: Action(ActionType.Discard, tile=99)})
+        env.step({3: Action(ActionType.DISCARD, tile=99)})
 
         # Now Seat 2 discards winning tile (6 for 2m triplet)
         env.current_player = 2
         env.phase = Phase.WaitResponse
         env.last_discard = (2, 6)
         env.active_players = [3]
-        env.current_claims = {3: [Action(ActionType.Ron, tile=6)]}
+        env.current_claims = {3: [Action(ActionType.RON, tile=6)]}
 
         # Result:
         # Winner: Seat 3 (Ko)
@@ -66,7 +66,7 @@ class TestPaoHonba:
         # Discarder pays 16000.
         # Pao pays 16600.
 
-        env.step({3: Action(ActionType.Ron, tile=6)})
+        env.step({3: Action(ActionType.RON, tile=6)})
 
         hora = next(m for m in reversed(env.mjai_log) if m["type"] == "hora")
         deltas = hora["deltas"]

--- a/tests/env/rule_validation/test_claim_priority.py
+++ b/tests/env/rule_validation/test_claim_priority.py
@@ -31,15 +31,15 @@ class TestClaimPriority:
         )
 
         # P0 Discards 57
-        env.step({0: Action(ActionType.Discard, tile=57)})
+        env.step({0: Action(ActionType.DISCARD, tile=57)})
         assert env.phase == Phase.WaitResponse
 
         # We expect P1 and P2 to be in active_players if they have legal actions.
         assert env.active_players == [1, 2]
 
         # Submit Actions: P1 Chi, P2 Pon
-        action_chi = Action(ActionType.Chi, tile=57, consume_tiles=[62, 65])
-        action_pon = Action(ActionType.Pon, tile=57, consume_tiles=[56, 58])
+        action_chi = Action(ActionType.CHI, tile=57, consume_tiles=[62, 65])
+        action_pon = Action(ActionType.PON, tile=57, consume_tiles=[56, 58])
         actions = {1: action_chi, 2: action_pon}
 
         # Step

--- a/tests/env/rule_validation/test_furiten_rules.py
+++ b/tests/env/rule_validation/test_furiten_rules.py
@@ -81,7 +81,7 @@ def test_furiten_ron():
     env.hands = hands
 
     # Perform discard step
-    actions = {target_player: Action(ActionType.Discard, tile=discard_tile)}
+    actions = {target_player: Action(ActionType.DISCARD, tile=discard_tile)}
     obs_dict = env.step(actions)
 
     # Should now be in WaitResponse phase (if Ron/Pon/Chi is possible)
@@ -121,11 +121,11 @@ def test_ron_allowed_without_furiten():
     hands[target_player].append(discard_tile)
     env.hands = hands
 
-    actions = {target_player: Action(ActionType.Discard, tile=discard_tile)}
+    actions = {target_player: Action(ActionType.DISCARD, tile=discard_tile)}
     obs_dict = env.step(actions)
 
     # P0 should now be able to Ron.
     assert 0 in obs_dict, "Player 0 should be active (No Furiten -> Ron allowed)"
     obs0 = obs_dict[0]
-    ron_moves = [a for a in obs0.legal_actions() if a.action_type == ActionType.Ron]
+    ron_moves = [a for a in obs0.legal_actions() if a.action_type == ActionType.RON]
     assert len(ron_moves) > 0, "Ron should be allowed when not in Furiten"

--- a/tests/env/rule_validation/test_kuikae.py
+++ b/tests/env/rule_validation/test_kuikae.py
@@ -22,7 +22,7 @@ class TestKuikae:
 
         # P1 discards 1s (72).
         discard_tile = 72
-        action_discard = Action(ActionType.Discard, discard_tile, [])
+        action_discard = Action(ActionType.DISCARD, discard_tile, [])
 
         obs_dict = env.step({1: action_discard})
 
@@ -33,12 +33,12 @@ class TestKuikae:
 
         # 1s 2s 3s Chi involves consuming 2s + 3s.
         assert env.phase == Phase.WaitResponse
-        assert any(a.action_type == ActionType.Chi for a in actions), "Chi should be offered"
-        obs2 = env.step({2: Action(ActionType.Chi, 72, [79, 82])})
+        assert any(a.action_type == ActionType.CHI for a in actions), "Chi should be offered"
+        obs2 = env.step({2: Action(ActionType.CHI, 72, [79, 82])})
 
         # P2 should not be able to discard 4s
         actions = obs2[2].legal_actions()
-        assert not any(a.action_type == ActionType.Discard for a in actions if a.tile // 4 == 21)
+        assert not any(a.action_type == ActionType.DISCARD for a in actions if a.tile // 4 == 21)
 
     def test_kuikae_suji_chi_avoid_kuikae_deadlock(self) -> None:
         env = helper_setup_env(
@@ -66,7 +66,7 @@ class TestKuikae:
 
         # P1 discards 1s (72).
         discard_tile = 72
-        action_discard = Action(ActionType.Discard, discard_tile, [])
+        action_discard = Action(ActionType.DISCARD, discard_tile, [])
 
         obs_dict = env.step({1: action_discard})
 
@@ -95,7 +95,7 @@ class TestKuikae:
 
         # P1 discards 1s (72).
         discard_tile = 72
-        obs = env.step({1: Action(ActionType.Discard, discard_tile, [])})
+        obs = env.step({1: Action(ActionType.DISCARD, discard_tile, [])})
 
         # P2 should be active with Chi offer.
         assert 2 in obs, "P2 should be active"
@@ -104,7 +104,7 @@ class TestKuikae:
         # Find Chi action
         chi_action = None
         for a in actions:
-            if a.action_type == ActionType.Chi:
+            if a.action_type == ActionType.CHI:
                 # We want to consume 2s(79), 3s(82)
                 if 79 in a.consume_tiles and 82 in a.consume_tiles:
                     chi_action = a
@@ -123,7 +123,7 @@ class TestKuikae:
         can_discard_7p = False
 
         for a in discard_actions:
-            if a.action_type == ActionType.Discard:
+            if a.action_type == ActionType.DISCARD:
                 t = a.tile
                 if t // 4 == 21:  # 4s
                     can_discard_4s = True

--- a/tests/env/rule_validation/test_riichi_sequence.py
+++ b/tests/env/rule_validation/test_riichi_sequence.py
@@ -88,8 +88,8 @@ class TestRiichiSequenceHandling:
         obs = obs_dict[3]
         legals = obs.legal_actions()
 
-        riichi_actions = [a for a in legals if a.action_type == ActionType.Riichi]
-        ankan_actions = [a for a in legals if a.action_type == ActionType.Ankan]
+        riichi_actions = [a for a in legals if a.action_type == ActionType.RIICHI]
+        ankan_actions = [a for a in legals if a.action_type == ActionType.ANKAN]
 
         assert len(riichi_actions) > 0, "Should be able to riichi when tenpai and menzen"
         assert len(ankan_actions) > 0, "Should be able to ankan with 4 tiles of 3m"
@@ -105,14 +105,14 @@ class TestRiichiSequenceHandling:
 
         # During riichi_stage (reach declared, awaiting discard), ankan is not offered.
         # Only discard actions are available at this point.
-        ankan_after_reach = [a for a in legals_after_reach if a.action_type == ActionType.Ankan]
+        ankan_after_reach = [a for a in legals_after_reach if a.action_type == ActionType.ANKAN]
         assert len(ankan_after_reach) == 0, "Ankan should NOT be available during riichi_stage"
 
-        discard_actions = [a for a in legals_after_reach if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in legals_after_reach if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0, "Should be able to discard after reach"
 
         # Riichi should NOT be available anymore (already in riichi_stage)
-        riichi_after_reach = [a for a in legals_after_reach if a.action_type == ActionType.Riichi]
+        riichi_after_reach = [a for a in legals_after_reach if a.action_type == ActionType.RIICHI]
         assert len(riichi_after_reach) == 0, "Riichi should not be available when already in riichi_stage"
 
     def test_mjai_reach_then_dahai_sequence(self) -> None:
@@ -168,7 +168,7 @@ class TestRiichiSequenceHandling:
         reach_action = obs.select_action_from_mjai(reach_response)
 
         assert reach_action is not None, "Should be able to select reach action"
-        assert reach_action.action_type == ActionType.Riichi, "Action type should be Riichi"
+        assert reach_action.action_type == ActionType.RIICHI, "Action type should be Riichi"
 
         # Step with reach action (no tile specified - this is the issue!)
         # RiichiEnv's Riichi action can optionally include a tile
@@ -185,13 +185,13 @@ class TestRiichiSequenceHandling:
 
         # Should only have discard actions available (and possibly ankan if wait unchanged)
         # But should NOT have Riichi available
-        riichi_in_new_legals = [a for a in new_legals if a.action_type == ActionType.Riichi]
+        riichi_in_new_legals = [a for a in new_legals if a.action_type == ActionType.RIICHI]
         assert len(riichi_in_new_legals) == 0, (
             f"Riichi should not be available after reach declaration. Legals: {new_legals}"
         )
 
         # Should have discard actions
-        discard_in_new_legals = [a for a in new_legals if a.action_type == ActionType.Discard]
+        discard_in_new_legals = [a for a in new_legals if a.action_type == ActionType.DISCARD]
         assert len(discard_in_new_legals) > 0, "Should have discard actions available"
 
         # Now simulate the dahai action
@@ -200,7 +200,7 @@ class TestRiichiSequenceHandling:
         dahai_action = new_obs.select_action_from_mjai(dahai_response)
 
         assert dahai_action is not None, f"Should be able to select dahai action. Legals: {new_legals}"
-        assert dahai_action.action_type == ActionType.Discard, "Action type should be Discard"
+        assert dahai_action.action_type == ActionType.DISCARD, "Action type should be Discard"
 
         # Step the env with the dahai action to complete the reach→dahai sequence
         env.step({3: dahai_action})
@@ -265,8 +265,8 @@ class TestRiichiSequenceHandling:
         legals = obs.legal_actions()
 
         # Check consistency with expected Mortal state after reach
-        can_discard = any(a.action_type == ActionType.Discard for a in legals)
-        can_riichi = any(a.action_type == ActionType.Riichi for a in legals)
+        can_discard = any(a.action_type == ActionType.DISCARD for a in legals)
+        can_riichi = any(a.action_type == ActionType.RIICHI for a in legals)
 
         assert can_discard is True, "Should be able to discard during riichi_stage"
         assert can_riichi is False, "Should NOT be able to riichi when already in riichi_stage"

--- a/tests/env/rule_validation/test_temporary_furiten.py
+++ b/tests/env/rule_validation/test_temporary_furiten.py
@@ -34,15 +34,15 @@ def test_temporary_furiten_chankan():
     env.phase = Phase.WaitAct
     discard_tile_5s = 88
 
-    obs_dict = env.step({1: Action(ActionType.Discard, discard_tile_5s, [])})
+    obs_dict = env.step({1: Action(ActionType.DISCARD, discard_tile_5s, [])})
 
     # P3 should be offered Ron.
     assert 3 in obs_dict
-    acts = [a for a in obs_dict[3].legal_actions() if a.action_type == ActionType.Ron]
+    acts = [a for a in obs_dict[3].legal_actions() if a.action_type == ActionType.RON]
     assert len(acts) > 0, "P3 should be offered Ron on 5s originally"
 
     # P3 PASSES.
-    env.step({3: Action(ActionType.Pass, None, [])})
+    env.step({3: Action(ActionType.PASS, None, [])})
 
     # Check if missed_agari_doujun is set for P3.
     assert env.missed_agari_doujun[3], "P3 should be in temporary furiten after passing Ron"
@@ -53,10 +53,10 @@ def test_temporary_furiten_chankan():
     env.active_players = [2]
     env.phase = Phase.WaitAct
 
-    obs_dict_2 = env.step({2: Action(ActionType.Discard, discard_tile_5s, [])})
+    obs_dict_2 = env.step({2: Action(ActionType.DISCARD, discard_tile_5s, [])})
 
     if 3 in obs_dict_2:
-        acts_2 = [a for a in obs_dict_2[3].legal_actions() if a.action_type == ActionType.Ron]
+        acts_2 = [a for a in obs_dict_2[3].legal_actions() if a.action_type == ActionType.RON]
         assert len(acts_2) == 0, "P3 should NOT be offered Ron due to Temporary Furiten"
     else:
         # If P3 not in obs, it means no actions offered (correct).

--- a/tests/env/rule_validation/test_valid_ankan.py
+++ b/tests/env/rule_validation/test_valid_ankan.py
@@ -24,5 +24,5 @@ class TestValidAnkanRiichiLegality:
         obs = obs_dict[2]
         legals = obs.legal_actions()
 
-        ankan = [a for a in legals if a.action_type == ActionType.Ankan]
+        ankan = [a for a in legals if a.action_type == ActionType.ANKAN]
         assert len(ankan) == 1, f"Ankan should be LEGAL as it does NOT change waits. Legals: {legals}"

--- a/tests/env/test_apply_event.py
+++ b/tests/env/test_apply_event.py
@@ -116,7 +116,7 @@ class TestApplyEvent4P:
         actions = obs.legal_actions()
         assert len(actions) > 0
         # Should have at least discard options
-        discard_actions = [a for a in actions if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in actions if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0
 
     def test_tsumo_returns_none_for_other_player(self):
@@ -137,8 +137,8 @@ class TestApplyEvent4P:
         assert obs is not None
         actions = obs.legal_actions()
         action_types = {a.action_type for a in actions}
-        assert ActionType.Pon in action_types
-        assert ActionType.Pass in action_types
+        assert ActionType.PON in action_types
+        assert ActionType.PASS in action_types
 
     def test_dahai_returns_none_when_no_reaction(self):
         """After P0 discards a tile no one can claim, returns None."""
@@ -209,7 +209,7 @@ class TestApplyEvent4P:
         obs = env.observe_event({"type": "pon", "actor": 1, "target": 0, "pai": "1m", "consumed": ["1m", "1m"]}, 1)
         assert obs is not None
         actions = obs.legal_actions()
-        discard_actions = [a for a in actions if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in actions if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0
 
     def test_chi_kuikae_forbids_called_and_other_side_tile(self):
@@ -232,7 +232,7 @@ class TestApplyEvent4P:
             1,
         )
         assert obs is not None
-        discard_t34 = {a.tile // 4 for a in obs.legal_actions() if a.action_type == ActionType.Discard}
+        discard_t34 = {a.tile // 4 for a in obs.legal_actions() if a.action_type == ActionType.DISCARD}
         # 3m (t34=2) is the called tile — forbidden
         assert 2 not in discard_t34, "3m (called tile) must be forbidden by kuikae"
         # 6m (t34=5) is the other-side tile of the 3-4-5 sequence — forbidden
@@ -301,7 +301,7 @@ class TestApplyEvent3P:
         assert obs is not None
         actions = obs.legal_actions()
         assert len(actions) > 0
-        discard_actions = [a for a in actions if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in actions if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0
 
     def test_tsumo_returns_none_for_other_player(self):
@@ -321,8 +321,8 @@ class TestApplyEvent3P:
         assert obs is not None
         actions = obs.legal_actions()
         action_types = {a.action_type for a in actions}
-        assert ActionType.Pon in action_types
-        assert ActionType.Pass in action_types
+        assert ActionType.PON in action_types
+        assert ActionType.PASS in action_types
 
     def test_dahai_returns_none_when_no_reaction(self):
         """P2 should not get reaction when P0 discards a tile P2 can't claim."""
@@ -370,7 +370,7 @@ class TestApplyEvent3P:
         obs = env.observe_event({"type": "pon", "actor": 1, "target": 0, "pai": "1p", "consumed": ["1p", "1p"]}, 1)
         assert obs is not None
         actions = obs.legal_actions()
-        discard_actions = [a for a in actions if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in actions if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0
 
     def test_kita_returns_none_for_other(self):
@@ -537,9 +537,9 @@ class TestReplayFuriten:
                 p1_pass_has_ron = []
                 for step in kyoku.steps(seat=None, skip_single_action=False):
                     pid, obs, action = step
-                    if pid == 1 and action.action_type == ActionType.Pass:
+                    if pid == 1 and action.action_type == ActionType.PASS:
                         types = {a.action_type for a in obs.legal_actions()}
-                        p1_pass_has_ron.append(ActionType.Ron in types)
+                        p1_pass_has_ron.append(ActionType.RON in types)
                 # Both passes should have Ron (doujun furiten resets after discard)
                 assert len(p1_pass_has_ron) == 2, f"expected 2 pass obs, got {len(p1_pass_has_ron)}"
                 assert p1_pass_has_ron[0] is True, "1st pass should include Ron"
@@ -591,9 +591,9 @@ class TestReplayFuriten:
                 p1_pass_has_ron = []
                 for step in kyoku.steps(seat=None, skip_single_action=False):
                     pid, obs, action = step
-                    if pid == 1 and action.action_type == ActionType.Pass:
+                    if pid == 1 and action.action_type == ActionType.PASS:
                         types = {a.action_type for a in obs.legal_actions()}
-                        p1_pass_has_ron.append(ActionType.Ron in types)
+                        p1_pass_has_ron.append(ActionType.RON in types)
                 # Only the first pass (from P0's 3m) should have Ron.
                 # The second 3m (from P2) produces no pass obs because
                 # riichi furiten blocks all claims.

--- a/tests/env/test_discard_type.py
+++ b/tests/env/test_discard_type.py
@@ -26,7 +26,7 @@ class TestDiscardType:
         env.hands = h
 
         # Action: Discard the drawn tile
-        env.step({0: Action(ActionType.Discard, tile=drawn_tile)})
+        env.step({0: Action(ActionType.DISCARD, tile=drawn_tile)})
 
         # Verify: Last discard for P0 should be Tsumogiri (from_hand=False)
         assert len(env.discard_from_hand[0]) == 1
@@ -54,7 +54,7 @@ class TestDiscardType:
         if hand_tile == new_drawn:
             hand_tile = env.hands[0][1]
 
-        env.step({0: Action(ActionType.Discard, tile=hand_tile)})
+        env.step({0: Action(ActionType.DISCARD, tile=hand_tile)})
 
         # Verify
         assert len(env.discard_from_hand[0]) == 2

--- a/tests/env/test_game_rules.py
+++ b/tests/env/test_game_rules.py
@@ -25,10 +25,10 @@ class TestGameRule:
         assert env._custom_round_wind == Wind.East
         assert env.honba == 0
 
-        obs = env.step({0: Action(ActionType.Discard, tile=80)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=80)})
         assert 1 in obs
-        assert any(a for a in obs[1].legal_actions() if a.action_type == ActionType.KyushuKyuhai)
-        env.step({1: Action(ActionType.KyushuKyuhai)})
+        assert any(a for a in obs[1].legal_actions() if a.action_type == ActionType.KYUSHU_KYUHAI)
+        env.step({1: Action(ActionType.KYUSHU_KYUHAI)})
         assert env.done()
 
     def test_tonpuu_ranchan_transitions(self) -> None:
@@ -51,10 +51,10 @@ class TestGameRule:
         assert env._custom_round_wind == Wind.East
         assert env.honba == 0
 
-        obs = env.step({0: Action(ActionType.Discard, tile=80)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=80)})
         assert 1 in obs
-        assert any(a for a in obs[1].legal_actions() if a.action_type == ActionType.KyushuKyuhai)
-        obs = env.step({1: Action(ActionType.KyushuKyuhai)})
+        assert any(a for a in obs[1].legal_actions() if a.action_type == ActionType.KYUSHU_KYUHAI)
+        obs = env.step({1: Action(ActionType.KYUSHU_KYUHAI)})
         assert not env.done()
 
         assert 0 in obs
@@ -85,10 +85,10 @@ class TestGameRule:
         assert env._custom_round_wind == Wind.East
         assert env.honba == 0
 
-        obs = env.step({0: Action(ActionType.Discard, tile=80)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=80)})
         assert 1 in obs
-        assert any(a for a in obs[1].legal_actions() if a.action_type == ActionType.KyushuKyuhai)
-        obs = env.step({1: Action(ActionType.KyushuKyuhai)})
+        assert any(a for a in obs[1].legal_actions() if a.action_type == ActionType.KYUSHU_KYUHAI)
+        obs = env.step({1: Action(ActionType.KYUSHU_KYUHAI)})
         assert not env.done()
 
         assert 0 in obs

--- a/tests/env/test_honba_reset.py
+++ b/tests/env/test_honba_reset.py
@@ -31,14 +31,14 @@ def test_honba_reset_on_ko_win():
     env.active_players = [0, 1, 2, 3]
 
     # Step where 0 discards
-    env.step({0: Action(ActionType.Discard, 25, [])})
+    env.step({0: Action(ActionType.DISCARD, 25, [])})
 
     # Now it should be WaitResponse phase, Player 1 can Ron
     assert env.phase == Phase.WaitResponse
     assert env.last_discard == (0, 25)  # (pid, tile)
 
     # Player 1 Rons
-    env.step({1: Action(ActionType.Ron, 25, [])})
+    env.step({1: Action(ActionType.RON, 25, [])})
 
     # Transition to end state
     env.step({})
@@ -65,7 +65,7 @@ def test_honba_increment_on_oya_win():
     env.needs_tsumo = False
     env.phase = Phase.WaitAct
 
-    env.step({0: Action(ActionType.Tsumo)})
+    env.step({0: Action(ActionType.TSUMO)})
 
     env.step({})
 

--- a/tests/env/test_illegal_actions.py
+++ b/tests/env/test_illegal_actions.py
@@ -19,7 +19,7 @@ class TestIllegalActions:
             invalid_tile += 1
 
         # Perform illegal action
-        action = Action(ActionType.Discard, tile=invalid_tile)
+        action = Action(ActionType.DISCARD, tile=invalid_tile)
         empty_dict = env.step({0: action})
 
         # NOTE: should return empty_dict?
@@ -74,8 +74,8 @@ class TestIllegalActions:
         valid_tile = p0_hand[-1]
 
         actions = {
-            0: Action(ActionType.Discard, tile=valid_tile),  # Valid
-            1: Action(ActionType.Discard, tile=0),  # Illegal (Out of turn)
+            0: Action(ActionType.DISCARD, tile=valid_tile),  # Valid
+            1: Action(ActionType.DISCARD, tile=0),  # Illegal (Out of turn)
         }
         env.step(actions)
 
@@ -112,9 +112,9 @@ class TestIllegalActions:
         valid_tile = p0_hand[-1]
 
         actions = {
-            0: Action(ActionType.Discard, tile=valid_tile),
-            1: Action(ActionType.Discard, tile=0),
-            2: Action(ActionType.Discard, tile=0),
+            0: Action(ActionType.DISCARD, tile=valid_tile),
+            1: Action(ActionType.DISCARD, tile=0),
+            2: Action(ActionType.DISCARD, tile=0),
         }
 
         env.step(actions)

--- a/tests/env/test_kan_dora_timing_events.py
+++ b/tests/env/test_kan_dora_timing_events.py
@@ -38,7 +38,7 @@ class TestKanDoraTimingEvents:
         obs = obs_dict[player_id]
 
         # Find ankan action
-        ankan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Ankan]
+        ankan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.ANKAN]
         assert len(ankan_actions) > 0, "Should have ANKAN action available"
 
         # Execute ankan
@@ -92,7 +92,7 @@ class TestKanDoraTimingEvents:
         obs = obs_dict[player_id]
 
         # Find kakan action
-        kakan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Kakan]
+        kakan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.KAKAN]
         assert len(kakan_actions) > 0, "Should have KAKAN action available"
 
         # Execute kakan
@@ -101,7 +101,7 @@ class TestKanDoraTimingEvents:
         # Now we need to discard
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
-        discard_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0, "Should have DISCARD action available"
 
         # Execute discard
@@ -158,7 +158,7 @@ class TestKanDoraTimingEvents:
         env.drawn_tile = 75
 
         # Step 1: Player 0 discards tile 75
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=75)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=75)})
 
         # Step 2: Player 1 calls DAIMINKAN
         assert 1 in obs_dict, "Player 1 should be active"
@@ -171,7 +171,7 @@ class TestKanDoraTimingEvents:
         player_id = 1
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
-        discard_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0, "Should have DISCARD action available"
         env.step({player_id: discard_actions[0]})
 
@@ -232,7 +232,7 @@ class TestKanDoraTimingEvents3P:
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
 
-        ankan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Ankan]
+        ankan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.ANKAN]
         assert len(ankan_actions) > 0, "Should have ANKAN action available"
 
         env.step({player_id: ankan_actions[0]})
@@ -283,7 +283,7 @@ class TestKanDoraTimingEvents3P:
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
 
-        kakan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Kakan]
+        kakan_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.KAKAN]
         assert len(kakan_actions) > 0, "Should have KAKAN action available"
 
         env.step({player_id: kakan_actions[0]})
@@ -291,7 +291,7 @@ class TestKanDoraTimingEvents3P:
         # Now discard after rinshan draw
         obs_dict = env.get_observations([player_id])
         obs = obs_dict[player_id]
-        discard_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.Discard]
+        discard_actions = [a for a in obs.legal_actions() if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0, "Should have DISCARD action available"
         env.step({player_id: discard_actions[0]})
 

--- a/tests/env/test_m263_ron_mismatch.py
+++ b/tests/env/test_m263_ron_mismatch.py
@@ -51,14 +51,14 @@ def test_ron_mismatch_after_call():
     env.current_player = 1
     env.phase = Phase.WaitAct
     # P1 discards 1p (36).
-    obs = env.step({1: Action(ActionType.Discard, 36)})
+    obs = env.step({1: Action(ActionType.DISCARD, 36)})
 
     # P3 calls Pon
     # (Consume 37, 38)
-    env.step({3: Action(ActionType.Pon, 36, [37, 38])})
+    env.step({3: Action(ActionType.PON, 36, [37, 38])})
 
     # P3 discards dummy (2p - 40).
-    obs = env.step({3: Action(ActionType.Discard, 40)})
+    obs = env.step({3: Action(ActionType.DISCARD, 40)})
 
     # Now P3 should NO LONGER be in temporary furiten.
     # P2 discards 7s (93).
@@ -68,10 +68,10 @@ def test_ron_mismatch_after_call():
 
     env.current_player = 2
     env.phase = Phase.WaitAct
-    obs = env.step({2: Action(ActionType.Discard, 93)})
+    obs = env.step({2: Action(ActionType.DISCARD, 93)})
 
     # P3 should be offered Ron.
     assert 3 in obs, "P3 should be active for Ron"
     actions = obs[3].legal_actions()
     action_types = [a.action_type for a in actions]
-    assert ActionType.Ron in action_types, f"P3 should have Ron offered. Actions: {action_types}"
+    assert ActionType.RON in action_types, f"P3 should have Ron offered. Actions: {action_types}"

--- a/tests/env/test_majsoul_pao_scoring.py
+++ b/tests/env/test_majsoul_pao_scoring.py
@@ -55,7 +55,7 @@ class TestPaoCompositeYakuman:
         env.phase = Phase.WaitAct
 
         # Execute Tsumo
-        action = Action(ActionType.Tsumo)
+        action = Action(ActionType.TSUMO)
         env.step({0: action})
         assert env.win_results[0].yakuman
 
@@ -149,12 +149,12 @@ class TestPaoCompositeYakuman:
         env.phase = Phase.WaitAct
 
         # Discard 122
-        action = Action(ActionType.Discard, 122, [])
+        action = Action(ActionType.DISCARD, 122, [])
         env.step({1: action})
 
         assert env.phase == Phase.WaitResponse
 
-        action_ron = Action(ActionType.Ron, 122, [])
+        action_ron = Action(ActionType.RON, 122, [])
         env.step({0: action_ron})
 
         # Expected: Triple Yakuman (Daisuushi 2x + Tsuuiisou 1x) = 144000.
@@ -219,11 +219,11 @@ class TestPaoCompositeYakuman:
         env.phase = Phase.WaitAct
 
         # Discard 4
-        action = Action(ActionType.Discard, 4, [])
+        action = Action(ActionType.DISCARD, 4, [])
         env.step({1: action})
 
         assert env.phase == Phase.WaitResponse
-        action_ron = Action(ActionType.Ron, 4, [])
+        action_ron = Action(ActionType.RON, 4, [])
         env.step({0: action_ron})
 
         # Expected: Single Yakuman (48000).
@@ -289,12 +289,12 @@ class TestPaoCompositeYakuman:
         env.needs_tsumo = False
         env.phase = Phase.WaitAct
 
-        action = Action(ActionType.Discard, 113, [])
+        action = Action(ActionType.DISCARD, 113, [])
         env.step({0: action})
 
         assert env.phase == Phase.WaitResponse
 
-        action_ron = Action(ActionType.Ron, 113, [])
+        action_ron = Action(ActionType.RON, 113, [])
         env.step({2: action_ron})
 
         # Double yakuman (Daisangen 1x + Tsuuiisou 1x) = 64000 (ko).
@@ -349,11 +349,11 @@ class TestPaoCompositeYakuman:
         env.needs_tsumo = False
         env.phase = Phase.WaitAct
 
-        action = Action(ActionType.Discard, 113, [])
+        action = Action(ActionType.DISCARD, 113, [])
         env.step({0: action})
         assert env.phase == Phase.WaitResponse
 
-        action_ron = Action(ActionType.Ron, 113, [])
+        action_ron = Action(ActionType.RON, 113, [])
         env.step({2: action_ron})
 
         # 64000 + 1000 riichi deposit = 65000 for winner.

--- a/tests/env/test_riichi_markers.py
+++ b/tests/env/test_riichi_markers.py
@@ -16,7 +16,7 @@ class TestRiichiMarker:
         env.hands = hands
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        riichi_actions = [a for a in legals if a.action_type == ActionType.Riichi]
+        riichi_actions = [a for a in legals if a.action_type == ActionType.RIICHI]
         assert len(riichi_actions) > 0, "Manual setup did not provide Riichi opportunity"
 
         # 1. Declare Riichi
@@ -33,7 +33,7 @@ class TestRiichiMarker:
         # We must pick a legal discard.
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        discards = [a for a in legals if a.action_type == ActionType.Discard]
+        discards = [a for a in legals if a.action_type == ActionType.DISCARD]
         assert len(discards) > 0
         discard_action = discards[0]
 
@@ -69,7 +69,7 @@ class TestRiichiMarker:
         # P0 just discards naturally
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        discards = [a for a in legals if a.action_type == ActionType.Discard]
+        discards = [a for a in legals if a.action_type == ActionType.DISCARD]
 
         if discards:
             env.step({0: discards[0]})
@@ -88,7 +88,7 @@ class TestRiichiMarker:
         env.hands = hands
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        riichi_actions = [a for a in legals if a.action_type == ActionType.Riichi]
+        riichi_actions = [a for a in legals if a.action_type == ActionType.RIICHI]
         assert riichi_actions
 
         env.step({0: riichi_actions[0]})
@@ -96,7 +96,7 @@ class TestRiichiMarker:
         # Discard
         obs = env.get_observations([0])[0]
         legals = obs.legal_actions()
-        discards = [a for a in legals if a.action_type == ActionType.Discard]
+        discards = [a for a in legals if a.action_type == ActionType.DISCARD]
         env.step({0: discards[0]})
 
         # Check markers set

--- a/tests/env/test_riichi_no_claims.py
+++ b/tests/env/test_riichi_no_claims.py
@@ -19,15 +19,15 @@ def test_no_chi_during_riichi():
         wall=list(range(136)),
     )
 
-    action = Action(ActionType.Discard, 72, [])
+    action = Action(ActionType.DISCARD, 72, [])
     obs_dict = env.step({1: action})
 
     assert 2 in obs_dict, "Player 2 should be active (Draw/Tsumo) but with NO claims offered"
     obs2 = obs_dict[2]
     actions = obs2.legal_actions()
 
-    chi_actions = [a for a in actions if a.action_type == ActionType.Chi]
-    pon_actions = [a for a in actions if a.action_type == ActionType.Pon]
+    chi_actions = [a for a in actions if a.action_type == ActionType.CHI]
+    pon_actions = [a for a in actions if a.action_type == ActionType.PON]
 
     assert len(chi_actions) == 0, f"Chi should NOT be offered during Riichi! Offered: {chi_actions}"
     assert len(pon_actions) == 0, f"Pon should NOT be offered during Riichi! Offered: {pon_actions}"
@@ -48,14 +48,14 @@ def test_chi_offered_when_not_in_riichi():
         wall=list(range(136)),
     )
 
-    action = Action(ActionType.Discard, 72, [])
+    action = Action(ActionType.DISCARD, 72, [])
     obs_dict = env.step({1: action})
 
     assert 2 in obs_dict, f"Player 2 should be in active players when NOT in Riichi, but obs_dict was {obs_dict.keys()}"
     obs2 = obs_dict[2]
     actions = obs2.legal_actions()
 
-    chi_actions = [a for a in actions if a.action_type == ActionType.Chi]
+    chi_actions = [a for a in actions if a.action_type == ActionType.CHI]
     assert len(chi_actions) > 0, "Player 2 should have Chi actions when NOT in Riichi"
 
 
@@ -74,15 +74,15 @@ def test_no_pon_during_riichi():
         wall=list(range(136)),
     )
 
-    action = Action(ActionType.Discard, 78, [])
+    action = Action(ActionType.DISCARD, 78, [])
     obs_dict = env.step({1: action})
 
     assert 2 in obs_dict, "Player 2 should be active (Draw/Tsumo) but with NO claims offered"
     obs2 = obs_dict[2]
     actions = obs2.legal_actions()
 
-    chi_actions = [a for a in actions if a.action_type == ActionType.Chi]
-    pon_actions = [a for a in actions if a.action_type == ActionType.Pon]
+    chi_actions = [a for a in actions if a.action_type == ActionType.CHI]
+    pon_actions = [a for a in actions if a.action_type == ActionType.PON]
 
     assert len(chi_actions) == 0, f"Chi should NOT be offered during Riichi! Offered: {chi_actions}"
     assert len(pon_actions) == 0, f"Pon should NOT be offered during Riichi! Offered: {pon_actions}"

--- a/tests/env/test_riichienv.py
+++ b/tests/env/test_riichienv.py
@@ -76,13 +76,13 @@ class TestRiichiEnv:
         assert list(obs_dict.keys()) == [0]
         obs = obs_dict[0]
         tile_to_discard = obs.hand[-1]
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=tile_to_discard)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=tile_to_discard)})
 
         # Players who can act are stored in `env.active_players`
         # Multiple players may be able to act in the `Phase.WaitResponse` phase
         # If no one can act, the `Phase.WaitResponse` phase is skipped
         while env.phase == Phase.WaitResponse:
-            actions = {pid: Action(ActionType.Pass) for pid in env.active_players}
+            actions = {pid: Action(ActionType.PASS) for pid in env.active_players}
             obs_dict = env.step(actions)
 
         # WaitAct phase for the next player
@@ -151,7 +151,7 @@ class TestRiichiEnv:
         p0_events = []
 
         p0_tile = p0_obs.hand[0]
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=p0_tile)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=p0_tile)})
         collect_p0(obs_dict, p0_events)
 
         assert env.phase == Phase.WaitAct
@@ -174,11 +174,11 @@ class TestRiichiEnv:
             assert new_evs[-1]["actor"] == actor
 
             discard_tile = obs.hand[0]
-            obs_dict = env.step({pid: Action(ActionType.Discard, tile=discard_tile)})
+            obs_dict = env.step({pid: Action(ActionType.DISCARD, tile=discard_tile)})
             collect_p0(obs_dict, p0_events)
 
             if env.phase == Phase.WaitResponse:
-                obs_dict = env.step({pid: Action(ActionType.Pass) for pid in env.active_players})
+                obs_dict = env.step({pid: Action(ActionType.PASS) for pid in env.active_players})
                 collect_p0(obs_dict, p0_events)
 
         assert env.phase == Phase.WaitAct
@@ -212,7 +212,7 @@ class TestRiichiEnv:
         env.current_player = 0
         env.drawn_tile = 52  # 5p
 
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=0)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=0)})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [2]
         assert list(obs_dict.keys()) == [2]
@@ -254,7 +254,7 @@ class TestRiichiEnv:
         env.current_player = 0
         env.drawn_tile = 16  # 5mr
 
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=16)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=16)})
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [2]
         assert list(obs_dict.keys()) == [2]
@@ -578,7 +578,7 @@ class TestRiichiEnv:
         h[0].sort()
         env.hands = h
 
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=tile_5m_target)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=tile_5m_target)})
 
         assert env.phase == Phase.WaitResponse
         assert env.active_players == [1]
@@ -586,7 +586,7 @@ class TestRiichiEnv:
 
         # P1 Legal Ron
         obs = obs_dict[1]
-        ron = [a for a in obs.legal_actions() if a.action_type == ActionType.Ron]
+        ron = [a for a in obs.legal_actions() if a.action_type == ActionType.RON]
         assert len(ron) == 1
 
         # Execute Ron
@@ -630,5 +630,5 @@ class TestRiichiEnv:
 
         # In this scenario, 1s,1s,1s,1s were part of a 1s,2s,3s sequence wait.
         # Ankan would change the waits, so it should be ILLEGAL.
-        ankan = [a for a in legals if a.action_type == ActionType.Ankan]
+        ankan = [a for a in legals if a.action_type == ActionType.ANKAN]
         assert len(ankan) == 0, f"Ankan should be illegal as it changes waits. Legals: {legals}"

--- a/tests/env/test_riichienv_hora.py
+++ b/tests/env/test_riichienv_hora.py
@@ -41,14 +41,14 @@ class TestRiichiEnv:
 
         # P0 performs Kakan
         env.needs_tsumo = False
-        obs_dict = env.step({0: Action(ActionType.Kakan, tile=63)})
+        obs_dict = env.step({0: Action(ActionType.KAKAN, tile=63)})
 
         # Verify P1 can Ron
         assert env.phase == Phase.WaitResponse
         assert 1 in env.active_players
         obs1 = obs_dict[1]
         legals = obs1.legal_actions()
-        ron = [a for a in legals if a.action_type == ActionType.Ron]
+        ron = [a for a in legals if a.action_type == ActionType.RON]
         assert len(ron) == 1
 
         # Execute Ron
@@ -86,13 +86,13 @@ class TestRiichiEnv:
 
         # Step: P2 discards 9p
         env.needs_tsumo = False
-        obs_dict = env.step({2: Action(ActionType.Discard, tile=discard_tile)})
+        obs_dict = env.step({2: Action(ActionType.DISCARD, tile=discard_tile)})
 
         assert pid in obs_dict, "P3 should receive an observation after discard."
         legals = obs_dict[pid].legal_actions()
-        has_ron = any(a.action_type == ActionType.Ron for a in legals)
+        has_ron = any(a.action_type == ActionType.RON for a in legals)
         assert has_ron, "Ron should be legal because South (Bakaze) is a Yaku in a South round."
-        obs_dict = env.step({pid: Action(ActionType.Ron, tile=discard_tile)})
+        obs_dict = env.step({pid: Action(ActionType.RON, tile=discard_tile)})
         # 11: 役牌:場風牌 => 南
         # 21: 対々和
         # 22: 三暗刻

--- a/tests/env/test_sanma.py
+++ b/tests/env/test_sanma.py
@@ -34,9 +34,9 @@ def _play_one_turn(env, obs):
     pid = env.current_player
     o = obs[pid]
     tile = o.hand[-1]
-    obs = env.step({pid: Action(ActionType.Discard, tile=tile)})
+    obs = env.step({pid: Action(ActionType.DISCARD, tile=tile)})
     while env.phase == Phase.WaitResponse:
-        actions = {p: Action(ActionType.Pass) for p in env.active_players}
+        actions = {p: Action(ActionType.PASS) for p in env.active_players}
         obs = env.step(actions)
     return obs
 
@@ -142,7 +142,7 @@ class TestSanmaNoChi:
             pid = env.current_player
             o = obs[pid]
             for a in o.legal_actions():
-                assert a.action_type != ActionType.Chi, "Chi must not appear in sanma"
+                assert a.action_type != ActionType.CHI, "Chi must not appear in sanma"
             obs = _play_one_turn(env, obs)
 
     def test_shimocha_cannot_chi(self):
@@ -160,12 +160,12 @@ class TestSanmaNoChi:
         env.drawn_tile = 88
 
         # P0 discards 1p (36) - P1 has 2p(41),3p(45) but cannot Chi
-        obs = env.step({0: Action(ActionType.Discard, tile=36)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=36)})
         if env.phase == Phase.WaitResponse:
             for pid in env.active_players:
                 if pid in obs:
                     for a in obs[pid].legal_actions():
-                        assert a.action_type != ActionType.Chi
+                        assert a.action_type != ActionType.CHI
 
 
 # ===========================================================================
@@ -188,12 +188,12 @@ class TestSanmaPon:
         env.active_players = [0]
         env.drawn_tile = 88
 
-        obs = env.step({0: Action(ActionType.Discard, tile=36)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=36)})
         assert env.phase == Phase.WaitResponse
 
         # P1 should have pon option
         obs_p1 = obs[1]
-        pon_actions = [a for a in obs_p1.legal_actions() if a.action_type == ActionType.Pon]
+        pon_actions = [a for a in obs_p1.legal_actions() if a.action_type == ActionType.PON]
         assert len(pon_actions) > 0
 
         # Execute pon
@@ -418,10 +418,10 @@ class TestSanmaScoring:
         env.discards = d
 
         actions = env._get_legal_actions(0)
-        tsumo = next((a for a in actions if a.action_type == ActionType.Tsumo), None)
+        tsumo = next((a for a in actions if a.action_type == ActionType.TSUMO), None)
         assert tsumo is not None, f"Expected tsumo in legal actions: {actions}"
 
-        env.step({0: Action(ActionType.Tsumo)})
+        env.step({0: Action(ActionType.TSUMO)})
         hora = next(e for e in reversed(env.mjai_log) if e["type"] == "hora")
         assert hora["tsumo"] is True
         deltas = hora["deltas"]
@@ -449,11 +449,11 @@ class TestSanmaScoring:
         env.active_players = [0]
         env.drawn_tile = 96
 
-        obs = env.step({0: Action(ActionType.Discard, tile=1)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=1)})
         assert env.phase == Phase.WaitResponse
         assert 1 in obs
 
-        ron_acts = [a for a in obs[1].legal_actions() if a.action_type == ActionType.Ron]
+        ron_acts = [a for a in obs[1].legal_actions() if a.action_type == ActionType.RON]
         assert len(ron_acts) == 1
 
         env.step({1: ron_acts[0]})
@@ -486,14 +486,14 @@ class TestSanmaGameFlow:
             o = obs[pid]
             # Try tsumo first if available
             legals = o.legal_actions()
-            tsumo = next((a for a in legals if a.action_type == ActionType.Tsumo), None)
+            tsumo = next((a for a in legals if a.action_type == ActionType.TSUMO), None)
             if tsumo:
                 obs = env.step({pid: tsumo})
             else:
                 tile = o.hand[-1]
-                obs = env.step({pid: Action(ActionType.Discard, tile=tile)})
+                obs = env.step({pid: Action(ActionType.DISCARD, tile=tile)})
             while env.phase == Phase.WaitResponse and not env.is_done:
-                actions = {p: Action(ActionType.Pass) for p in env.active_players}
+                actions = {p: Action(ActionType.PASS) for p in env.active_players}
                 obs = env.step(actions)
             turns += 1
         assert env.is_done or turns >= 200
@@ -516,11 +516,11 @@ class TestSanmaGameFlow:
         env, obs = _create_sanma_env()
         # P0 discards
         tile = obs[0].hand[-1]
-        obs = env.step({0: Action(ActionType.Discard, tile=tile)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=tile)})
 
         # Handle WaitResponse
         while env.phase == Phase.WaitResponse:
-            actions = {p: Action(ActionType.Pass) for p in env.active_players}
+            actions = {p: Action(ActionType.PASS) for p in env.active_players}
             obs = env.step(actions)
 
         # P1 should see events including start_kyoku with 3 player tehais
@@ -550,7 +550,7 @@ class TestSanmaMjaiAction:
         mjai_str = tid_to_mjai(tile)
         action = o.select_action_from_mjai({"type": "dahai", "pai": mjai_str, "actor": 0})
         assert action is not None
-        assert action.action_type == ActionType.Discard
+        assert action.action_type == ActionType.DISCARD
 
     def test_select_action_from_mjai_pass(self):
         """Pass should always be selectable during WaitResponse."""
@@ -565,12 +565,12 @@ class TestSanmaMjaiAction:
         env.active_players = [0]
         env.drawn_tile = 88
 
-        obs = env.step({0: Action(ActionType.Discard, tile=36)})
+        obs = env.step({0: Action(ActionType.DISCARD, tile=36)})
         if 1 in obs:
             o = obs[1]
             action = o.select_action_from_mjai({"type": "none"})
             assert action is not None
-            assert action.action_type == ActionType.Pass
+            assert action.action_type == ActionType.PASS
 
 
 # ===========================================================================

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -189,13 +189,13 @@ def test_only_aka_dora_fails():
 
 def test_reach_action_to_mjai_includes_actor():
     # actor ありの reach → to_mjai() に "actor" が含まれる
-    action = Action(type=ActionType.Riichi, actor=2)
+    action = Action(type=ActionType.RIICHI, actor=2)
     result = json.loads(action.to_mjai())
     assert result["type"] == "reach"
     assert result["actor"] == 2, f"Expected actor=2, got {result.get('actor')}"
 
     # actor なしの reach → "actor" キーが存在しない
-    action_no_actor = Action(type=ActionType.Riichi)
+    action_no_actor = Action(type=ActionType.RIICHI)
     result2 = json.loads(action_no_actor.to_mjai())
     assert result2["type"] == "reach"
     assert "actor" not in result2, f"actor key should not exist, got {result2}"

--- a/tests/test_env_scoring.py
+++ b/tests/test_env_scoring.py
@@ -22,16 +22,16 @@ class TestRiichiScoring:
         env.hands = h
 
         # P1 discards 126
-        obs = env.step({1: Action(ActionType.Discard, tile=126)})
+        obs = env.step({1: Action(ActionType.DISCARD, tile=126)})
 
         # P0 should have Ron option
         assert 0 in obs
         actions = obs[0].legal_actions()
-        ron_action = next((a for a in actions if a.action_type == ActionType.Ron), None)
+        ron_action = next((a for a in actions if a.action_type == ActionType.RON), None)
         assert ron_action is not None
 
         # P0 declares Ron
-        env.step({0: Action(ActionType.Ron, tile=126)})
+        env.step({0: Action(ActionType.RON, tile=126)})
 
         # Check log
         hora_event = next(e for e in reversed(env.mjai_log) if e["type"] == "hora")
@@ -64,11 +64,11 @@ class TestRiichiScoring:
 
         # Verify legal actions
         actions = env._get_legal_actions(0)
-        tsumo_act = next((a for a in actions if a.action_type == ActionType.Tsumo), None)
+        tsumo_act = next((a for a in actions if a.action_type == ActionType.TSUMO), None)
         assert tsumo_act is not None
 
         # Execute Tsumo
-        env.step({0: Action(ActionType.Tsumo)})
+        env.step({0: Action(ActionType.TSUMO)})
 
         # Check log
         hora_event = next(e for e in reversed(env.mjai_log) if e["type"] == "hora")
@@ -101,7 +101,7 @@ class TestRiichiScoring:
         env.drawn_tile = 13
         env.current_player = 0
 
-        env.step({0: Action(ActionType.Tsumo)})
+        env.step({0: Action(ActionType.TSUMO)})
 
         hora_event = next(e for e in reversed(env.mjai_log) if e["type"] == "hora")
         assert len(hora_event["ura_markers"]) > 0
@@ -136,7 +136,7 @@ class TestRiichiScoring:
         env.discards = d  # Reassign for PyO3
 
         # Execute Tsumo
-        env.step({0: Action(ActionType.Tsumo)})
+        env.step({0: Action(ActionType.TSUMO)})
         hora_event = next(e for e in reversed(env.mjai_log) if e["type"] == "hora")
 
         deltas = hora_event["deltas"]

--- a/tests/test_midway_draw.py
+++ b/tests/test_midway_draw.py
@@ -21,7 +21,7 @@ class TestAbortiveDraw:
             h[p][0] = tiles[i]
             env.hands = h
             env.drawn_tile = tiles[i]
-            env.step({p: Action(ActionType.Discard, tile=tiles[i])})
+            env.step({p: Action(ActionType.DISCARD, tile=tiles[i])})
             if i < 3:
                 assert not env.done()
 
@@ -45,7 +45,7 @@ class TestAbortiveDraw:
         )
 
         p = env.current_player
-        env.step({p: Action(ActionType.Discard, tile=108)})
+        env.step({p: Action(ActionType.DISCARD, tile=108)})
 
         assert env.done()
         assert any(e["reason"] == "suukansansen" for e in env.mjai_log if e["type"] == "ryukyoku")

--- a/tests/test_mjai_parity.py
+++ b/tests/test_mjai_parity.py
@@ -8,13 +8,13 @@ from .env.helper import helper_setup_env
 class TestMjaiProtocol:
     def test_action_to_mjai_red_fives(self):
         # Test red fives mapping to 5mr, 5pr, 5sr
-        act_m = Action(ActionType.Discard, tile=16)
+        act_m = Action(ActionType.DISCARD, tile=16)
         assert '"pai":"5mr"' in act_m.to_mjai()
 
-        act_p = Action(ActionType.Discard, tile=52)
+        act_p = Action(ActionType.DISCARD, tile=52)
         assert '"pai":"5pr"' in act_p.to_mjai()
 
-        act_s = Action(ActionType.Discard, tile=88)
+        act_s = Action(ActionType.DISCARD, tile=88)
         assert '"pai":"5sr"' in act_s.to_mjai()
 
     def test_select_action_from_mjai_discard(self):
@@ -23,14 +23,14 @@ class TestMjaiProtocol:
         obs = obs_dict[0]
 
         # Get a legal discard
-        legal_discards = [a for a in obs.legal_actions() if a.action_type == ActionType.Discard]
+        legal_discards = [a for a in obs.legal_actions() if a.action_type == ActionType.DISCARD]
         target_act = legal_discards[0]
         mjai_resp = json.loads(target_act.to_mjai())
 
         # Select from MJAI
         selected = obs.select_action_from_mjai(mjai_resp)
         assert selected is not None
-        assert selected.action_type == ActionType.Discard
+        assert selected.action_type == ActionType.DISCARD
         assert selected.tile == target_act.tile
 
     def test_select_action_from_mjai_chi(self):
@@ -52,10 +52,10 @@ class TestMjaiProtocol:
         # P0 discards 3m.
         # Manually trigger discard and claim update.
         env.current_player = 0
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=9)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=9)})
 
         obs1 = obs_dict[1]
-        chi_acts = [a for a in obs1.legal_actions() if a.action_type == ActionType.Chi]
+        chi_acts = [a for a in obs1.legal_actions() if a.action_type == ActionType.CHI]
         assert len(chi_acts) > 0
 
         target_act = chi_acts[0]
@@ -63,7 +63,7 @@ class TestMjaiProtocol:
 
         selected = obs1.select_action_from_mjai(mjai_resp)
         assert selected is not None
-        assert selected.action_type == ActionType.Chi
+        assert selected.action_type == ActionType.CHI
         assert set(selected.consume_tiles) == set(target_act.consume_tiles)
 
     def test_select_action_from_mjai_none(self):
@@ -81,9 +81,9 @@ class TestMjaiProtocol:
             wall=list(range(136)),
         )
         # tile 9 is in P0 hand (3m)
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=9)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=9)})
         obs1 = obs_dict[1]
 
         selected = obs1.select_action_from_mjai({"type": "none"})
         assert selected is not None
-        assert selected.action_type == ActionType.Pass
+        assert selected.action_type == ActionType.PASS

--- a/tests/test_mjai_replay.py
+++ b/tests/test_mjai_replay.py
@@ -139,13 +139,13 @@ def test_mjai_replay_3p_reach_discard_observation_is_not_duplicated_state(tmp_pa
     riichi_obs, riichi_act = steps[0]
     discard_obs, discard_act = steps[1]
 
-    assert riichi_act.action_type == ActionType.Riichi
-    assert discard_act.action_type == ActionType.Discard
+    assert riichi_act.action_type == ActionType.RIICHI
+    assert discard_act.action_type == ActionType.DISCARD
 
     riichi_legals = [a.action_type for a in riichi_obs.legal_actions()]
     discard_legals = [a.action_type for a in discard_obs.legal_actions()]
-    assert ActionType.Riichi in riichi_legals
-    assert ActionType.Riichi not in discard_legals
+    assert ActionType.RIICHI in riichi_legals
+    assert ActionType.RIICHI not in discard_legals
 
 
 def test_mjai_replay_4p_reach_discard_observation_is_not_duplicated_state(tmp_path):
@@ -188,10 +188,10 @@ def test_mjai_replay_4p_reach_discard_observation_is_not_duplicated_state(tmp_pa
     riichi_obs, riichi_act = steps[0]
     discard_obs, discard_act = steps[1]
 
-    assert riichi_act.action_type == ActionType.Riichi
-    assert discard_act.action_type == ActionType.Discard
+    assert riichi_act.action_type == ActionType.RIICHI
+    assert discard_act.action_type == ActionType.DISCARD
 
     riichi_legals = [a.action_type for a in riichi_obs.legal_actions()]
     discard_legals = [a.action_type for a in discard_obs.legal_actions()]
-    assert ActionType.Riichi in riichi_legals
-    assert ActionType.Riichi not in discard_legals
+    assert ActionType.RIICHI in riichi_legals
+    assert ActionType.RIICHI not in discard_legals

--- a/tests/test_observation_serialization.py
+++ b/tests/test_observation_serialization.py
@@ -66,10 +66,10 @@ class TestObservationSerialization:
             pid = env.current_player
             obs = obs_dict[pid]
             tile = obs.hand[-1]
-            obs_dict = env.step({pid: Action(ActionType.Discard, tile=tile)})
+            obs_dict = env.step({pid: Action(ActionType.DISCARD, tile=tile)})
             # Handle WaitResponse phase (pass all claims)
             while env.phase == Phase.WaitResponse:
-                actions = {p: Action(ActionType.Pass) for p in env.active_players}
+                actions = {p: Action(ActionType.PASS) for p in env.active_players}
                 obs_dict = env.step(actions)
 
         if not env.is_done:
@@ -99,14 +99,14 @@ class TestObservationSerialization:
         ]
 
         discard = dealer_obs.hand[0]
-        obs_dict = env.step({0: Action(ActionType.Discard, tile=discard)})
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=discard)})
 
         for pid in [1, 2, 3]:
             obs = obs_dict[pid]
             discard = obs.hand[0]
-            obs_dict = env.step({pid: Action(ActionType.Discard, tile=discard)})
+            obs_dict = env.step({pid: Action(ActionType.DISCARD, tile=discard)})
             if env.phase == Phase.WaitResponse:
-                obs_dict = env.step({player: Action(ActionType.Pass) for player in env.active_players})
+                obs_dict = env.step({player: Action(ActionType.PASS) for player in env.active_players})
 
         dealer_obs_2 = obs_dict[0]
         assert [event["type"] for event in dealer_obs_2.events] == [

--- a/tests/test_riichi_autoplay.py
+++ b/tests/test_riichi_autoplay.py
@@ -30,7 +30,7 @@ def test_riichi_autoplay():
     # The wall needs to be set up so P0 draws a safe tile.
 
     # Let's mock _perform_discard to set up P0 state explicitly or call it.
-    # Calling env.step({env.current_player: Action(ActionType.Discard, 100)}) on P3's turn:
+    # Calling env.step({env.current_player: Action(ActionType.DISCARD, 100)}) on P3's turn:
     # 1. P3 discards 100.
     # 2. Check Ron/Pon/Chi... assume none.
     # 3. Next player P0 draws.
@@ -61,14 +61,14 @@ def test_riichi_autoplay():
     # If drawn_tile=None, assumes manual discard from hand.
     env.drawn_tile = None
 
-    obs = env.step({env.current_player: Action(ActionType.Discard, 100)})  # P3 discards 100
+    obs = env.step({env.current_player: Action(ActionType.DISCARD, 100)})  # P3 discards 100
 
     # In Rust, Riichi doesn't auto-play immediately if drawn. It waits for explicit discard.
     # So P0 should be active now (Tsumo).
     assert env.current_player == 0
     # P0 must discard drawn tile (101).
     dt = env.drawn_tile
-    obs = env.step({0: Action(ActionType.Discard, dt)})
+    obs = env.step({0: Action(ActionType.DISCARD, dt)})
 
     # Check if P1 is active
     assert list(obs.keys()) == [1]


### PR DESCRIPTION
Add the missing `KITA` variant to `ActionType`, enabling proper type-checking and IDE autocompletion for 3-player (sanma) Kita/Nuki actions. Also, rename all `ActionType` enum members from PascalCase to `SCREAMING_SNAKE_CASE` following PEP 8 naming conventions for constants, using PyO3's `rename_all = "SCREAMING_SNAKE_CASE"` attribute.

## Backward compatibility

PascalCase names (`ActionType.Discard`, `ActionType.Tsumo`, etc.) remain accessible via runtime aliases defined in `action.py`. Existing user code will continue to work without changes, though migrating to `SCREAMING_SNAKE_CASE` is recommended.

Closes #167