### PR TITLE
fix: avoid impossible ukeire draws in shanten efficiency

### DIFF
--- a/riichienv-core/src/shanten.rs
+++ b/riichienv-core/src/shanten.rs
@@ -306,6 +306,13 @@ pub fn calculate_best_ukeire(hand_tiles: &[u32], visible_tiles: &[u32]) -> u32 {
             .filter(|(i, _)| *i != idx)
             .map(|(_, &t)| t)
             .collect();
+        let mut new_hand_counts = [0u8; TILE_MAX];
+        for &tile in &new_hand {
+            let tile_type = (tile / 4) as usize;
+            if tile_type < TILE_MAX {
+                new_hand_counts[tile_type] += 1;
+            }
+        }
 
         let new_shanten = calculate_shanten(&new_hand);
         if new_shanten > current_shanten {
@@ -314,6 +321,10 @@ pub fn calculate_best_ukeire(hand_tiles: &[u32], visible_tiles: &[u32]) -> u32 {
 
         let mut ukeire = 0;
         for tile_type in 0..34 {
+            if new_hand_counts[tile_type as usize] >= 4 {
+                continue;
+            }
+
             let mut test_hand = new_hand.clone();
             test_hand.push(tile_type * 4);
             let test_shanten = calculate_shanten(&test_hand);
@@ -466,6 +477,13 @@ pub fn calculate_best_ukeire_3p(hand_tiles: &[u32], visible_tiles: &[u32]) -> u3
             .filter(|(i, _)| *i != idx)
             .map(|(_, &t)| t)
             .collect();
+        let mut new_hand_counts = [0u8; TILE_MAX];
+        for &tile in &new_hand {
+            let tile_type = (tile / 4) as usize;
+            if tile_type < TILE_MAX {
+                new_hand_counts[tile_type] += 1;
+            }
+        }
 
         let new_shanten = calculate_shanten_3p(&new_hand);
         if new_shanten > current_shanten {
@@ -474,6 +492,10 @@ pub fn calculate_best_ukeire_3p(hand_tiles: &[u32], visible_tiles: &[u32]) -> u3
 
         let mut ukeire = 0;
         for &tile_type in &SANMA_VALID_TILE_TYPES {
+            if new_hand_counts[tile_type as usize] >= 4 {
+                continue;
+            }
+
             let mut test_hand = new_hand.clone();
             test_hand.push(tile_type * 4);
             let test_shanten = calculate_shanten_3p(&test_hand);

--- a/scripts/repro_encode_shanten_efficiency_houou.py
+++ b/scripts/repro_encode_shanten_efficiency_houou.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Reproduce the Houou shanten-efficiency panic from a Tenhou JSON paipu."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import riichienv
+
+DEFAULT_LOG_ID = "2024010100gm-00a9-0000-1d4dbec0"
+DEFAULT_PAIPU_DIR = (
+    Path(__file__).resolve().parents[2] / "tenhou-analysis" / "tenhou-data-extractor" / "paipu"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert one Tenhou JSON replay with mjai-reviewer and scan replay decisions "
+            "until encode_shanten_efficiency() panics."
+        )
+    )
+    parser.add_argument(
+        "--paipu-dir",
+        type=Path,
+        default=DEFAULT_PAIPU_DIR,
+        help=f"Directory containing Tenhou JSON logs (default: {DEFAULT_PAIPU_DIR})",
+    )
+    parser.add_argument(
+        "--log-id",
+        default=DEFAULT_LOG_ID,
+        help=f"Replay log id without extension (default: {DEFAULT_LOG_ID})",
+    )
+    parser.add_argument(
+        "--round-index",
+        type=int,
+        default=None,
+        help="Optional zero-based round index to scan. Defaults to all rounds.",
+    )
+    parser.add_argument(
+        "--seat",
+        type=int,
+        default=None,
+        help="Optional seat filter for replay decisions.",
+    )
+    parser.add_argument(
+        "--decision-index",
+        type=int,
+        default=None,
+        help="Optional zero-based decision index within each scanned round.",
+    )
+    parser.add_argument(
+        "--mjai-reviewer-cmd",
+        default="mjai-reviewer",
+        help="Command prefix for mjai-reviewer (default: mjai-reviewer)",
+    )
+    parser.add_argument(
+        "--mjai-out",
+        type=Path,
+        default=None,
+        help="Optional path to keep the converted MJAI log instead of using a temp file.",
+    )
+    parser.add_argument(
+        "--expect-panic",
+        action="store_true",
+        help="Exit non-zero if the panic is not reproduced.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_command(command_text: str) -> list[str]:
+    command = shlex.split(command_text)
+    if not command:
+        raise SystemExit("mjai-reviewer command must not be empty")
+
+    executable = command[0]
+    if shutil.which(executable) is None and not Path(executable).exists():
+        raise SystemExit(f"mjai-reviewer executable not found: {executable}")
+    return command
+
+
+def _convert_to_mjai(
+    tenhou_json_path: Path,
+    mjai_out: Path,
+    mjai_reviewer_cmd: str,
+) -> None:
+    command = [
+        *_resolve_command(mjai_reviewer_cmd),
+        "--no-review",
+        "-i",
+        str(tenhou_json_path),
+        "--mjai-out",
+        str(mjai_out),
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip()
+        stdout = exc.stdout.strip()
+        detail = stderr or stdout or f"exit code {exc.returncode}"
+        raise SystemExit(f"mjai-reviewer failed: {' '.join(command)}\n{detail}") from exc
+
+
+def _iter_steps(kyoku, seat: int | None):
+    if seat is None:
+        for decision_index, (pid, obs, act) in enumerate(kyoku.steps(skip_single_action=False)):
+            yield decision_index, pid, obs, act
+        return
+
+    for decision_index, (obs, act) in enumerate(kyoku.steps(seat=seat, skip_single_action=False)):
+        yield decision_index, seat, obs, act
+
+
+def _hand_to_tiles(hand: list[int]) -> list[str]:
+    return [riichienv.convert.tid_to_mjai(tile) for tile in hand]
+
+
+def main() -> int:
+    args = _parse_args()
+
+    tenhou_json_path = args.paipu_dir / f"{args.log_id}.json"
+    if not tenhou_json_path.exists():
+        print(f"Tenhou JSON not found: {tenhou_json_path}", file=sys.stderr)
+        return 2
+
+    if args.mjai_out is not None:
+        mjai_path = args.mjai_out
+        mjai_path.parent.mkdir(parents=True, exist_ok=True)
+        cleanup = None
+    else:
+        cleanup = tempfile.TemporaryDirectory(prefix="riichienv-shanten-repro-")
+        mjai_path = Path(cleanup.name) / f"{args.log_id}.mjson"
+
+    try:
+        _convert_to_mjai(tenhou_json_path, mjai_path, args.mjai_reviewer_cmd)
+        replay = riichienv.MjaiReplay.from_jsonl(str(mjai_path))
+
+        panic_found = False
+        steps_scanned = 0
+        for round_index, kyoku in enumerate(replay.take_kyokus()):
+            if args.round_index is not None and round_index != args.round_index:
+                continue
+
+            for decision_index, pid, obs, act in _iter_steps(kyoku, args.seat):
+                if args.decision_index is not None and decision_index != args.decision_index:
+                    continue
+
+                steps_scanned += 1
+                try:
+                    obs.encode_shanten_efficiency()
+                except BaseException as exc:  # PanicException inherits BaseException
+                    panic_found = True
+                    print("encode_shanten_efficiency() panicked")
+                    print(f"log_id={args.log_id}")
+                    print(f"round_index={round_index}")
+                    print(f"decision_index={decision_index}")
+                    print(f"seat={pid}")
+                    print(f"action_type={act.action_type}")
+                    print(f"hand={' '.join(_hand_to_tiles(obs.hand))}")
+                    print(f"error={type(exc).__name__}: {exc}")
+                    break
+
+            if panic_found:
+                break
+
+        if not panic_found:
+            print(
+                "No panic reproduced while scanning "
+                f"{steps_scanned} decision(s) from {args.log_id}."
+            )
+            return 1 if args.expect_panic else 0
+
+        return 0
+    finally:
+        if cleanup is not None:
+            cleanup.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/env/test_apply_event.py
+++ b/tests/env/test_apply_event.py
@@ -119,6 +119,19 @@ class TestApplyEvent4P:
         discard_actions = [a for a in actions if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0
 
+    def test_encode_shanten_efficiency_handles_quad_draw(self):
+        env = self._make_env()
+        hand = ["5m", "7m", "2p", "3p", "4p", "2s", "2s", "4s", "6s", "7s", "8s", "8s", "8s"]
+        tehais = [_UNKNOWN_HAND_13, hand, _UNKNOWN_HAND_13, _UNKNOWN_HAND_13]
+
+        env.observe_event({"type": "start_game"}, 1)
+        env.observe_event(_start_kyoku_event_4p(tehais=tehais, oya=1), 1)
+        obs = env.observe_event({"type": "tsumo", "actor": 1, "pai": "8s"}, 1)
+
+        assert obs is not None
+        enc = obs.encode_shanten_efficiency()
+        assert len(enc) == 64
+
     def test_tsumo_returns_none_for_other_player(self):
         """Tsumo for a different seat should return None."""
         env = self._make_env()
@@ -303,6 +316,19 @@ class TestApplyEvent3P:
         assert len(actions) > 0
         discard_actions = [a for a in actions if a.action_type == ActionType.DISCARD]
         assert len(discard_actions) > 0
+
+    def test_encode_shanten_efficiency_handles_quad_draw(self):
+        env = self._make_env()
+        hand = ["1m", "9m", "2p", "3p", "4p", "2s", "2s", "4s", "6s", "7s", "8s", "8s", "8s"]
+        tehais = [_UNKNOWN_HAND_13, hand, _UNKNOWN_HAND_13]
+
+        env.observe_event({"type": "start_game"}, 1)
+        env.observe_event(_start_kyoku_event_3p(tehais=tehais, oya=1), 1)
+        obs = env.observe_event({"type": "tsumo", "actor": 1, "pai": "8s"}, 1)
+
+        assert obs is not None
+        enc = obs.encode_shanten_efficiency()
+        assert len(enc) == 48
 
     def test_tsumo_returns_none_for_other_player(self):
         env = self._make_env()


### PR DESCRIPTION
## Summary
- skip impossible draw candidates in `calculate_best_ukeire()` and `calculate_best_ukeire_3p()` when the post-discard hand already contains four copies of a tile
- add 4p/3p regression tests for `encode_shanten_efficiency()` on a quad-containing draw state
- add a standalone repro script for the Houou replay report so the bug can be scanned from a local Tenhou JSON paipu

## Problem
`encode_shanten_efficiency()` could panic on a real Tenhou replay because the ukeire search was evaluating illegal five-of-a-kind hypothetical hands. The panic surfaced from the nyanten lookup in `riichienv-core/src/shanten.rs`.

## Repro
Before this fix, the following replay reproduced the panic locally:
- log id: `2024010100gm-00a9-0000-1d4dbec0`
- first failing scan on this branch's repro harness: `round_index=0`, `decision_index=90`, `seat=1`

## Verification
- `uv run maturin develop`
- `uv run pytest tests/env/test_apply_event.py -k 'encode_shanten_efficiency_handles_quad_draw'`
- `uv run pytest tests/test_shanten.py tests/env/test_sanma.py -k 'shanten'`
- `uv run python scripts/repro_encode_shanten_efficiency_houou.py`
