### PR TITLE
ci: add security audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,49 @@
+name: Security Audit
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+      - run: uv sync --all-extras --dev
+      - run: uv tool install pip-audit
+      - run: uv tool run pip-audit
+
+  rust-audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit
+
+  node-audit:
+    name: npm audit (riichienv-ui)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - working-directory: riichienv-ui
+        run: npm ci
+      - working-directory: riichienv-ui
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary\n- add a scheduled and on-demand security audit workflow\n- run pip-audit for Python dependencies\n- run cargo-audit for Rust dependencies\n- run npm audit at high severity for the UI package\n\n## Why\nRiichiEnv already has strong CI coverage for tests/lint/builds, but it currently lacks a dedicated dependency vulnerability check across its Python, Rust, and Node surfaces. This PR adds lightweight supply-chain scanning without changing runtime behavior.