### PR TITLE
fix: prevent underflow in ukeire calculation

### DIFF
--- a/riichienv-core/src/shanten.rs
+++ b/riichienv-core/src/shanten.rs
@@ -763,7 +763,10 @@ mod tests {
         let visible = vec![11 * 4, 11 * 4 + 1, 11 * 4 + 2];
 
         let ukeire = calculate_best_ukeire(&hand, &visible);
-        assert_eq!(ukeire, 2, "over-visible waits should clamp at zero remaining");
+        assert_eq!(
+            ukeire, 2,
+            "over-visible waits should clamp at zero remaining"
+        );
     }
 
     #[test]
@@ -778,6 +781,9 @@ mod tests {
         let visible = vec![20 * 4, 20 * 4 + 1, 20 * 4 + 2];
 
         let ukeire = calculate_best_ukeire_3p(&hand, &visible);
-        assert_eq!(ukeire, 2, "over-visible waits should clamp at zero remaining");
+        assert_eq!(
+            ukeire, 2,
+            "over-visible waits should clamp at zero remaining"
+        );
     }
 }


### PR DESCRIPTION
- Use `saturating_sub` instead of plain subtraction in `calculate_best_ukeire` and `calculate_best_ukeire_3p` to prevent u32 underflow when visible tile counts exceed the remaining copies of a tile type.
- Add regression tests for both 4-player and 3-player variants to verify the saturation behavior.