### PR TITLE
fix: disambiguate select_action_from_mjai with tsumogiri/consumed (#195)

### DIFF
--- a/riichienv-core/src/observation/encode.rs
+++ b/riichienv-core/src/observation/encode.rs
@@ -616,6 +616,7 @@ mod tests {
             [None; 4],  // riichi_sutehais
             [None; 4],  // last_tedashis
             None,       // last_discard
+            None,       // drawn_tile
         )
     }
 

--- a/riichienv-core/src/observation/mjai_select.rs
+++ b/riichienv-core/src/observation/mjai_select.rs
@@ -1,0 +1,189 @@
+//! Shared helpers for mapping Mjai messages to a legal `Action`.
+//!
+//! Used by both `Observation::select_action_from_mjai` (4P) and
+//! `Observation3P::select_action_from_mjai` (3P).
+
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyDictMethods};
+
+use crate::action::{Action, ActionType};
+use crate::parser::tid_to_mjai;
+
+pub(crate) struct ParsedMjai {
+    pub type_str: String,
+    pub tile_str: String,
+    pub tsumogiri: Option<bool>,
+    pub consumed: Option<Vec<String>>,
+}
+
+pub(crate) fn parse_mjai_message(mjai_data: &Bound<'_, PyAny>) -> Option<ParsedMjai> {
+    if let Ok(s) = mjai_data.extract::<String>() {
+        let v: serde_json::Value = serde_json::from_str(&s).ok()?;
+        let type_str = v["type"].as_str()?.to_string();
+        let tile_str = v["pai"].as_str().unwrap_or("").to_string();
+        let tsumogiri = v.get("tsumogiri").and_then(|x| x.as_bool());
+        let consumed = v.get("consumed").and_then(|x| x.as_array()).map(|arr| {
+            arr.iter()
+                .filter_map(|e| e.as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>()
+        });
+        Some(ParsedMjai {
+            type_str,
+            tile_str,
+            tsumogiri,
+            consumed,
+        })
+    } else if let Ok(dict) = mjai_data.cast::<PyDict>() {
+        let type_str: String = dict
+            .get_item("type")
+            .ok()
+            .flatten()
+            .and_then(|x| x.extract::<String>().ok())
+            .unwrap_or_default();
+        let tile_str: String = dict
+            .get_item("pai")
+            .ok()
+            .flatten()
+            .or_else(|| dict.get_item("tile").ok().flatten())
+            .and_then(|x| x.extract::<String>().ok())
+            .unwrap_or_default();
+        let tsumogiri = dict
+            .get_item("tsumogiri")
+            .ok()
+            .flatten()
+            .and_then(|x| x.extract::<bool>().ok());
+        let consumed = dict
+            .get_item("consumed")
+            .ok()
+            .flatten()
+            .and_then(|x| x.extract::<Vec<String>>().ok());
+        Some(ParsedMjai {
+            type_str,
+            tile_str,
+            tsumogiri,
+            consumed,
+        })
+    } else {
+        None
+    }
+}
+
+fn consumed_matches(action_consume: &[u8], expected: &[String]) -> bool {
+    if action_consume.len() != expected.len() {
+        return false;
+    }
+    let mut a: Vec<String> = action_consume.iter().map(|&t| tid_to_mjai(t)).collect();
+    let mut b: Vec<String> = expected.to_vec();
+    a.sort();
+    b.sort();
+    a == b
+}
+
+/// Select a matching `Action` from a slice of legal actions for a parsed Mjai
+/// message.
+///
+/// `three_player` controls whether 3P-only types (`kita`) are recognized; chi
+/// is rejected when set.
+pub(crate) fn select_action<'a>(
+    legal_actions: &'a [Action],
+    parsed: &ParsedMjai,
+    drawn_tile: Option<u8>,
+    three_player: bool,
+) -> Option<&'a Action> {
+    let atype = parsed.type_str.as_str();
+
+    if atype == "hora" {
+        return legal_actions
+            .iter()
+            .find(|a| matches!(a.action_type, ActionType::Tsumo | ActionType::Ron));
+    }
+
+    if atype == "none" {
+        return legal_actions
+            .iter()
+            .find(|a| a.action_type == ActionType::Pass);
+    }
+
+    let target_type = match atype {
+        "dahai" => Some(ActionType::Discard),
+        "chi" if !three_player => Some(ActionType::Chi),
+        "pon" => Some(ActionType::Pon),
+        "kakan" => Some(ActionType::Kakan),
+        "daiminkan" => Some(ActionType::Daiminkan),
+        "ankan" => Some(ActionType::Ankan),
+        "kita" if three_player => Some(ActionType::Kita),
+        "reach" => Some(ActionType::Riichi),
+        "ryukyoku" => Some(ActionType::KyushuKyuhai),
+        _ => None,
+    };
+
+    let tt = target_type?;
+
+    // Special-case Discard: filter by mjai pai then disambiguate via tsumogiri.
+    if tt == ActionType::Discard {
+        let candidates: Vec<&Action> = legal_actions
+            .iter()
+            .filter(|a| {
+                a.action_type == ActionType::Discard
+                    && a.tile.is_some_and(|t| tid_to_mjai(t) == parsed.tile_str)
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        if let (Some(tsumogiri), Some(drawn)) = (parsed.tsumogiri, drawn_tile) {
+            let preferred = candidates.iter().find(|a| {
+                let is_drawn = a.tile == Some(drawn);
+                if tsumogiri { is_drawn } else { !is_drawn }
+            });
+            if let Some(a) = preferred {
+                return Some(*a);
+            }
+        }
+
+        return Some(candidates[0]);
+    }
+
+    legal_actions.iter().find(|a| {
+        if a.action_type != tt {
+            return false;
+        }
+
+        if let Some(consumed) = parsed.consumed.as_ref() {
+            if !consumed_matches(&a.consume_tiles, consumed) {
+                return false;
+            }
+            // If pai is also given, double-check tile match for actions that
+            // carry a meaningful tile (chi/pon/daiminkan/kakan).
+            if !parsed.tile_str.is_empty()
+                && matches!(
+                    tt,
+                    ActionType::Chi
+                        | ActionType::Pon
+                        | ActionType::Daiminkan
+                        | ActionType::Kakan
+                )
+            {
+                if let Some(t) = a.tile {
+                    if tid_to_mjai(t) != parsed.tile_str {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // No consumed field: fall back to pai-based match.
+        if !parsed.tile_str.is_empty() {
+            if let Some(t) = a.tile {
+                return tid_to_mjai(t) == parsed.tile_str;
+            }
+            return false;
+        }
+        true
+    })
+}

--- a/riichienv-core/src/observation/mjai_select.rs
+++ b/riichienv-core/src/observation/mjai_select.rs
@@ -160,10 +160,7 @@ pub(crate) fn select_action<'a>(
             if !parsed.tile_str.is_empty()
                 && matches!(
                     tt,
-                    ActionType::Chi
-                        | ActionType::Pon
-                        | ActionType::Daiminkan
-                        | ActionType::Kakan
+                    ActionType::Chi | ActionType::Pon | ActionType::Daiminkan | ActionType::Kakan
                 )
             {
                 if let Some(t) = a.tile {

--- a/riichienv-core/src/observation/mjai_select.rs
+++ b/riichienv-core/src/observation/mjai_select.rs
@@ -119,13 +119,21 @@ pub(crate) fn select_action<'a>(
 
     let tt = target_type?;
 
-    // Special-case Discard: filter by mjai pai then disambiguate via tsumogiri.
+    // Special-case Discard: filter by mjai pai (or any Discard if pai is
+    // omitted) then disambiguate via tsumogiri.
+    //
+    // NOTE: An mjai `dahai` message without a `pai` field is malformed per
+    // the protocol, but we still return a non-empty Action (the first
+    // legal Discard) instead of `None` to preserve backward compatibility
+    // with the previous implementation; bailing out here would silently
+    // break callers that rely on the old lenient behavior.
     if tt == ActionType::Discard {
         let candidates: Vec<&Action> = legal_actions
             .iter()
             .filter(|a| {
                 a.action_type == ActionType::Discard
-                    && a.tile.is_some_and(|t| tid_to_mjai(t) == parsed.tile_str)
+                    && (parsed.tile_str.is_empty()
+                        || a.tile.is_some_and(|t| tid_to_mjai(t) == parsed.tile_str))
             })
             .collect();
 

--- a/riichienv-core/src/observation/mod.rs
+++ b/riichienv-core/src/observation/mod.rs
@@ -3,6 +3,8 @@ mod encode;
 #[cfg(feature = "python")]
 pub(crate) mod helpers;
 #[cfg(feature = "python")]
+pub(crate) mod mjai_select;
+#[cfg(feature = "python")]
 mod python;
 #[cfg(feature = "python")]
 pub(crate) mod sequence_features;
@@ -49,6 +51,8 @@ pub struct Observation {
     pub riichi_sutehais: [Option<u8>; 4],
     pub last_tedashis: [Option<u8>; 4],
     pub last_discard: Option<u32>,
+    #[serde(default)]
+    pub drawn_tile: Option<u8>,
 }
 
 /// Pure Rust methods (no PyO3 dependency).
@@ -74,6 +78,7 @@ impl Observation {
         riichi_sutehais: [Option<u8>; 4],
         last_tedashis: [Option<u8>; 4],
         last_discard: Option<u32>,
+        drawn_tile: Option<u8>,
     ) -> Self {
         let hands_u32 = hands.map(|h| h.into_iter().map(|x| x as u32).collect());
         let discards_u32 = discards.map(|d| d.into_iter().map(|x| x as u32).collect());
@@ -101,6 +106,7 @@ impl Observation {
             riichi_sutehais,
             last_tedashis,
             last_discard,
+            drawn_tile,
         }
     }
 

--- a/riichienv-core/src/observation/python.rs
+++ b/riichienv-core/src/observation/python.rs
@@ -14,7 +14,7 @@ use super::helpers::get_next_tile;
 impl Observation {
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard))]
+    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard, drawn_tile=None))]
     pub fn py_new(
         player_id: u8,
         hands: Vec<Vec<u8>>,
@@ -35,6 +35,7 @@ impl Observation {
         riichi_sutehais: Vec<Option<u8>>,
         last_tedashis: Vec<Option<u8>>,
         last_discard: Option<u32>,
+        drawn_tile: Option<u8>,
     ) -> Self {
         let hands: [Vec<u8>; 4] = hands.try_into().expect("expected 4 hands");
         let melds: [Vec<Meld>; 4] = melds.try_into().expect("expected 4 melds");
@@ -68,6 +69,7 @@ impl Observation {
             riichi_sutehais,
             last_tedashis,
             last_discard,
+            drawn_tile,
         )
     }
 
@@ -120,100 +122,9 @@ impl Observation {
 
     #[pyo3(signature = (mjai_data))]
     pub fn select_action_from_mjai(&self, mjai_data: &Bound<'_, PyAny>) -> Option<Action> {
-        let (atype, tile_str) = if let Ok(s) = mjai_data.extract::<String>() {
-            let v: serde_json::Value = serde_json::from_str(&s).ok()?;
-            (
-                v["type"].as_str()?.to_string(),
-                v["pai"].as_str().unwrap_or("").to_string(),
-            )
-        } else if let Ok(dict) = mjai_data.cast::<PyDict>() {
-            let type_str: String = dict
-                .get_item("type")
-                .ok()
-                .flatten()
-                .and_then(|x| x.extract::<String>().ok())
-                .unwrap_or_default();
-            let _args_list: Vec<String> = dict
-                .get_item("args")
-                .ok()
-                .flatten()
-                .and_then(|x| x.extract::<Vec<String>>().ok())
-                .unwrap_or_default();
-            let _who: i8 = dict
-                .get_item("who")
-                .ok()
-                .flatten()
-                .and_then(|x| x.extract::<i8>().ok())
-                .unwrap_or(-1);
-            let tile_str: String = dict
-                .get_item("pai")
-                .ok()
-                .flatten()
-                .or_else(|| dict.get_item("tile").ok().flatten())
-                .and_then(|x| x.extract::<String>().ok())
-                .unwrap_or_default();
-            (type_str, tile_str)
-        } else {
-            return None;
-        };
-
-        let target_type = match atype.as_str() {
-            "dahai" => Some(crate::action::ActionType::Discard),
-            "chi" => Some(crate::action::ActionType::Chi),
-            "pon" => Some(crate::action::ActionType::Pon),
-            "kakan" => Some(crate::action::ActionType::Kakan),
-            "daiminkan" => Some(crate::action::ActionType::Daiminkan),
-            "ankan" => Some(crate::action::ActionType::Ankan),
-            "reach" => Some(crate::action::ActionType::Riichi),
-            "hora" => None,
-            "ryukyoku" => Some(crate::action::ActionType::KyushuKyuhai),
-            _ => None,
-        };
-
-        if atype == "hora" {
-            return self
-                ._legal_actions
-                .iter()
-                .find(|a| {
-                    a.action_type == crate::action::ActionType::Tsumo
-                        || a.action_type == crate::action::ActionType::Ron
-                })
-                .cloned();
-        }
-
-        if let Some(tt) = target_type {
-            return self
-                ._legal_actions
-                .iter()
-                .find(|a| {
-                    if a.action_type != tt {
-                        return false;
-                    }
-                    if !tile_str.is_empty() {
-                        if let Some(t) = a.tile {
-                            let t_str = crate::parser::tid_to_mjai(t);
-                            if t_str == tile_str {
-                                return true;
-                            }
-                            return false;
-                        } else {
-                            return false;
-                        }
-                    }
-                    true
-                })
-                .cloned();
-        }
-
-        if atype == "none" {
-            return self
-                ._legal_actions
-                .iter()
-                .find(|a| a.action_type == crate::action::ActionType::Pass)
-                .cloned();
-        }
-
-        None
+        use super::mjai_select::{parse_mjai_message, select_action};
+        let parsed = parse_mjai_message(mjai_data)?;
+        select_action(&self._legal_actions, &parsed, self.drawn_tile, false).cloned()
     }
 
     #[pyo3(name = "new_events")]

--- a/riichienv-core/src/observation_3p/encode.rs
+++ b/riichienv-core/src/observation_3p/encode.rs
@@ -650,6 +650,7 @@ mod tests {
             [None; 3],  // riichi_sutehais
             [None; 3],  // last_tedashis
             None,       // last_discard
+            None,       // drawn_tile
         )
     }
 

--- a/riichienv-core/src/observation_3p/mod.rs
+++ b/riichienv-core/src/observation_3p/mod.rs
@@ -41,6 +41,8 @@ pub struct Observation3P {
     pub riichi_sutehais: [Option<u8>; 3],
     pub last_tedashis: [Option<u8>; 3],
     pub last_discard: Option<u32>,
+    #[serde(default)]
+    pub drawn_tile: Option<u8>,
 }
 
 /// Pure Rust methods (no PyO3 dependency).
@@ -66,6 +68,7 @@ impl Observation3P {
         riichi_sutehais: [Option<u8>; 3],
         last_tedashis: [Option<u8>; 3],
         last_discard: Option<u32>,
+        drawn_tile: Option<u8>,
     ) -> Self {
         let hands_u32 = hands.map(|h| h.into_iter().map(|x| x as u32).collect());
         let discards_u32 = discards.map(|d| d.into_iter().map(|x| x as u32).collect());
@@ -95,6 +98,7 @@ impl Observation3P {
             riichi_sutehais,
             last_tedashis,
             last_discard,
+            drawn_tile,
         }
     }
 

--- a/riichienv-core/src/observation_3p/python.rs
+++ b/riichienv-core/src/observation_3p/python.rs
@@ -17,7 +17,7 @@ const TOTAL_TILES: u32 = 108;
 impl Observation3P {
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard))]
+    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard, drawn_tile=None))]
     pub fn py_new(
         player_id: u8,
         hands: Vec<Vec<u8>>,
@@ -38,6 +38,7 @@ impl Observation3P {
         riichi_sutehais: Vec<Option<u8>>,
         last_tedashis: Vec<Option<u8>>,
         last_discard: Option<u32>,
+        drawn_tile: Option<u8>,
     ) -> Self {
         let hands: [Vec<u8>; 3] = hands.try_into().expect("expected 3 hands");
         let melds: [Vec<Meld>; 3] = melds.try_into().expect("expected 3 melds");
@@ -71,6 +72,7 @@ impl Observation3P {
             riichi_sutehais,
             last_tedashis,
             last_discard,
+            drawn_tile,
         )
     }
 
@@ -122,101 +124,23 @@ impl Observation3P {
 
     #[pyo3(signature = (mjai_data))]
     pub fn select_action_from_mjai(&self, mjai_data: &Bound<'_, PyAny>) -> Option<Action3P> {
-        let (atype, tile_str) = if let Ok(s) = mjai_data.extract::<String>() {
-            let v: serde_json::Value = serde_json::from_str(&s).ok()?;
-            (
-                v["type"].as_str()?.to_string(),
-                v["pai"].as_str().unwrap_or("").to_string(),
-            )
-        } else if let Ok(dict) = mjai_data.cast::<PyDict>() {
-            let type_str: String = dict
-                .get_item("type")
-                .ok()
-                .flatten()
-                .and_then(|x| x.extract::<String>().ok())
-                .unwrap_or_default();
-            let _args_list: Vec<String> = dict
-                .get_item("args")
-                .ok()
-                .flatten()
-                .and_then(|x| x.extract::<Vec<String>>().ok())
-                .unwrap_or_default();
-            let _who: i8 = dict
-                .get_item("who")
-                .ok()
-                .flatten()
-                .and_then(|x| x.extract::<i8>().ok())
-                .unwrap_or(-1);
-            let tile_str: String = dict
-                .get_item("pai")
-                .ok()
-                .flatten()
-                .or_else(|| dict.get_item("tile").ok().flatten())
-                .and_then(|x| x.extract::<String>().ok())
-                .unwrap_or_default();
-            (type_str, tile_str)
-        } else {
-            return None;
-        };
-
-        let target_type = match atype.as_str() {
-            "dahai" => Some(crate::action::ActionType::Discard),
-            "chi" => Some(crate::action::ActionType::Chi),
-            "pon" => Some(crate::action::ActionType::Pon),
-            "kakan" => Some(crate::action::ActionType::Kakan),
-            "daiminkan" => Some(crate::action::ActionType::Daiminkan),
-            "ankan" => Some(crate::action::ActionType::Ankan),
-            "kita" => Some(crate::action::ActionType::Kita),
-            "reach" => Some(crate::action::ActionType::Riichi),
-            "hora" => None,
-            "ryukyoku" => Some(crate::action::ActionType::KyushuKyuhai),
-            _ => None,
-        };
-
-        if atype == "hora" {
-            return self
-                ._legal_actions
-                .iter()
-                .find(|a| {
-                    a.action_type == crate::action::ActionType::Tsumo
-                        || a.action_type == crate::action::ActionType::Ron
-                })
-                .cloned();
-        }
-
-        if let Some(tt) = target_type {
-            return self
-                ._legal_actions
-                .iter()
-                .find(|a| {
-                    if a.action_type != tt {
-                        return false;
-                    }
-                    if !tile_str.is_empty() {
-                        if let Some(t) = a.tile {
-                            let t_str = crate::parser::tid_to_mjai(t);
-                            if t_str == tile_str {
-                                return true;
-                            }
-                            return false;
-                        } else {
-                            return false;
-                        }
-                    }
-                    true
-                })
-                .cloned();
-        }
-
-        if atype == "none" {
-            return self
-                ._legal_actions
-                .iter()
-                .find(|a| a.action_type == crate::action::ActionType::Pass)
-                .cloned();
-        }
-
-        None
+        use crate::observation::mjai_select::{parse_mjai_message, select_action};
+        let parsed = parse_mjai_message(mjai_data)?;
+        let inner_actions: Vec<Action> = self
+            ._legal_actions
+            .iter()
+            .map(|a| (**a).clone())
+            .collect();
+        let selected = select_action(&inner_actions, &parsed, self.drawn_tile, true)?;
+        // Re-find the corresponding Action3P instance to return.
+        self._legal_actions
+            .iter()
+            .find(|a| {
+                a.action_type == selected.action_type
+                    && a.tile == selected.tile
+                    && a.consume_tiles == selected.consume_tiles
+            })
+            .cloned()
     }
 
     #[pyo3(name = "new_events")]

--- a/riichienv-core/src/observation_3p/python.rs
+++ b/riichienv-core/src/observation_3p/python.rs
@@ -126,11 +126,8 @@ impl Observation3P {
     pub fn select_action_from_mjai(&self, mjai_data: &Bound<'_, PyAny>) -> Option<Action3P> {
         use crate::observation::mjai_select::{parse_mjai_message, select_action};
         let parsed = parse_mjai_message(mjai_data)?;
-        let inner_actions: Vec<Action> = self
-            ._legal_actions
-            .iter()
-            .map(|a| (**a).clone())
-            .collect();
+        let inner_actions: Vec<Action> =
+            self._legal_actions.iter().map(|a| (**a).clone()).collect();
         let selected = select_action(&inner_actions, &parsed, self.drawn_tile, true)?;
         // Re-find the corresponding Action3P instance to return.
         self._legal_actions

--- a/riichienv-core/src/state/mod.rs
+++ b/riichienv-core/src/state/mod.rs
@@ -250,6 +250,7 @@ impl GameState {
             self.riichi_sutehais,
             self.last_tedashis,
             self.last_discard.map(|(tile, _pid)| tile as u32),
+            self.drawn_tile,
         );
 
         // Attach pre-computed progression snapshot.

--- a/riichienv-core/src/state_3p/mod.rs
+++ b/riichienv-core/src/state_3p/mod.rs
@@ -218,6 +218,7 @@ impl GameState3P {
             self.riichi_sutehais,
             self.last_tedashis,
             self.last_discard.map(|(tile, _pid)| tile as u32),
+            self.drawn_tile,
         )
     }
 

--- a/tests/test_mjai_parity.py
+++ b/tests/test_mjai_parity.py
@@ -148,6 +148,56 @@ class TestMjaiProtocol:
         assert sel_plain.action_type == ActionType.PON
         assert 16 not in sel_plain.consume_tiles  # no red 5m
 
+    def test_select_action_from_mjai_chi_consumed(self):
+        # When a 5m is discarded, the shimocha may be able to chi with three
+        # distinct shapes: (3m,4m), (4m,6m), or (6m,7m). The `consumed`
+        # field is the only way to disambiguate among them since they all
+        # share the same called tile (`pai="5m"`).
+        env = helper_setup_env(
+            seed=42,
+            hands=[
+                # P0: discards 5m (tid 17). 13 tiles + drawn=108 → 14.
+                [0, 4, 28, 32, 52, 56, 60, 64, 68, 92, 96, 100, 17],
+                # P1: shimocha, has 3m, 4m, 6m, 7m to enable all 3 chi shapes.
+                [8, 12, 20, 24, 36, 40, 44, 48, 72, 76, 80, 84, 109],
+                [],
+                [],
+            ],
+            current_player=0,
+            active_players=[0],
+            drawn_tile=108,
+            wall=list(range(136)),
+        )
+
+        # P0 discards 5m → P1 sees three chi options.
+        obs_dict = env.step({0: Action(ActionType.DISCARD, tile=17)})
+        obs1 = obs_dict[1]
+
+        chi_acts = [a for a in obs1.legal_actions() if a.action_type == ActionType.CHI]
+        assert len(chi_acts) == 3, [a.consume_tiles for a in chi_acts]
+
+        cases = [
+            (["3m", "4m"], {8, 12}),  # 3-4-5 (low)
+            (["4m", "6m"], {12, 20}),  # 4-5-6 (mid)
+            (["6m", "7m"], {20, 24}),  # 5-6-7 (high)
+        ]
+        for consumed_strs, expected_tiles in cases:
+            selected = obs1.select_action_from_mjai(
+                {
+                    "type": "chi",
+                    "actor": 1,
+                    "target": 0,
+                    "pai": "5m",
+                    "consumed": consumed_strs,
+                }
+            )
+            assert selected is not None, consumed_strs
+            assert selected.action_type == ActionType.CHI
+            assert set(selected.consume_tiles) == expected_tiles, (
+                consumed_strs,
+                set(selected.consume_tiles),
+            )
+
     def test_select_action_from_mjai_none(self):
         env = helper_setup_env(
             seed=42,

--- a/tests/test_mjai_parity.py
+++ b/tests/test_mjai_parity.py
@@ -66,6 +66,94 @@ class TestMjaiProtocol:
         assert selected.action_type == ActionType.CHI
         assert set(selected.consume_tiles) == set(target_act.consume_tiles)
 
+    def test_select_action_from_mjai_dahai_tsumogiri(self):
+        # Player has two non-red 5m in the existing hand and draws a third 5m.
+        # mjai's tsumogiri flag must disambiguate which Discard action is picked.
+        # Tile ids 17, 18 are non-red 5m; 16 is red 5m. Drawn tile = 19 (non-red 5m).
+        env = helper_setup_env(
+            seed=42,
+            hands=[
+                [0, 4, 17, 18, 36, 40, 44, 48, 72, 76, 80, 84, 108],
+                [3, 7, 11, 15, 23, 27, 31, 35, 39, 43, 47, 51, 109],
+                [],
+                [],
+            ],
+            current_player=0,
+            active_players=[0],
+            drawn_tile=19,
+        )
+        obs = env.get_observation(0)
+
+        # Tsumogiri=True must select the action whose tile is the drawn tile (19).
+        selected_t = obs.select_action_from_mjai(
+            {"type": "dahai", "actor": 0, "pai": "5m", "tsumogiri": True}
+        )
+        assert selected_t is not None
+        assert selected_t.action_type == ActionType.DISCARD
+        assert selected_t.tile == 19
+
+        # Tsumogiri=False must select an action whose tile is NOT the drawn tile.
+        selected_f = obs.select_action_from_mjai(
+            {"type": "dahai", "actor": 0, "pai": "5m", "tsumogiri": False}
+        )
+        assert selected_f is not None
+        assert selected_f.action_type == ActionType.DISCARD
+        assert selected_f.tile != 19
+        assert selected_f.tile in (17, 18)
+
+    def test_select_action_from_mjai_pon_consumed(self):
+        # Player has 5m red, 5m, 5m in hand and someone discards a 5m → two
+        # Pon actions exist (with and without the red 5m). The `consumed` field
+        # must disambiguate between them.
+        env = helper_setup_env(
+            seed=42,
+            hands=[
+                [0, 4, 8, 12, 16, 17, 18, 36, 40, 44, 48, 72, 76],  # P0: has 5mr,5m,5m
+                [3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47, 51, 108],  # P1
+                [],
+                [],
+            ],
+            current_player=1,
+            active_players=[1],
+            drawn_tile=108,
+        )
+        # P1 discards a non-red 5m (tile id 19).
+        env.step({1: Action(ActionType.DISCARD, tile=19)})
+        obs0 = env.get_observation(0)
+
+        pon_acts = [
+            a for a in obs0.legal_actions() if a.action_type == ActionType.PON
+        ]
+        assert len(pon_acts) >= 2  # both with and without aka
+
+        # With red 5m in consumed
+        sel_aka = obs0.select_action_from_mjai(
+            {
+                "type": "pon",
+                "actor": 0,
+                "target": 1,
+                "pai": "5m",
+                "consumed": ["5mr", "5m"],
+            }
+        )
+        assert sel_aka is not None
+        assert sel_aka.action_type == ActionType.PON
+        assert 16 in sel_aka.consume_tiles  # red 5m
+
+        # Without red 5m in consumed
+        sel_plain = obs0.select_action_from_mjai(
+            {
+                "type": "pon",
+                "actor": 0,
+                "target": 1,
+                "pai": "5m",
+                "consumed": ["5m", "5m"],
+            }
+        )
+        assert sel_plain is not None
+        assert sel_plain.action_type == ActionType.PON
+        assert 16 not in sel_plain.consume_tiles  # no red 5m
+
     def test_select_action_from_mjai_none(self):
         env = helper_setup_env(
             seed=42,

--- a/tests/test_mjai_parity.py
+++ b/tests/test_mjai_parity.py
@@ -85,17 +85,13 @@ class TestMjaiProtocol:
         obs = env.get_observation(0)
 
         # Tsumogiri=True must select the action whose tile is the drawn tile (19).
-        selected_t = obs.select_action_from_mjai(
-            {"type": "dahai", "actor": 0, "pai": "5m", "tsumogiri": True}
-        )
+        selected_t = obs.select_action_from_mjai({"type": "dahai", "actor": 0, "pai": "5m", "tsumogiri": True})
         assert selected_t is not None
         assert selected_t.action_type == ActionType.DISCARD
         assert selected_t.tile == 19
 
         # Tsumogiri=False must select an action whose tile is NOT the drawn tile.
-        selected_f = obs.select_action_from_mjai(
-            {"type": "dahai", "actor": 0, "pai": "5m", "tsumogiri": False}
-        )
+        selected_f = obs.select_action_from_mjai({"type": "dahai", "actor": 0, "pai": "5m", "tsumogiri": False})
         assert selected_f is not None
         assert selected_f.action_type == ActionType.DISCARD
         assert selected_f.tile != 19
@@ -121,9 +117,7 @@ class TestMjaiProtocol:
         env.step({1: Action(ActionType.DISCARD, tile=19)})
         obs0 = env.get_observation(0)
 
-        pon_acts = [
-            a for a in obs0.legal_actions() if a.action_type == ActionType.PON
-        ]
+        pon_acts = [a for a in obs0.legal_actions() if a.action_type == ActionType.PON]
         assert len(pon_acts) >= 2  # both with and without aka
 
         # With red 5m in consumed


### PR DESCRIPTION
Fixes #195. `Observation.select_action_from_mjai` and
  `Observation3P.select_action_from_mjai` matched legal actions using only
  the Mjai `type` and `pai` fields, which produced incorrect or
  inconsistent results in two scenarios.

## Changes

- Adds `drawn_tile` to `Observation` / `Observation3P` (back-compatible
  with existing base64 snapshots) and centralizes the Mjai-to-`Action`
  selection logic so that `tsumogiri` and `consumed` are honored.
- Removes the unreachable `chi` branch from the 3P `target_type` match
  for tidiness.

## Backward compatibility

- `serialize_to_base64` / `deserialize_from_base64` round-trip remains
  intact in both directions:
  - Old snapshots → new code: missing `drawn_tile` is filled with
    `None` thanks to `#[serde(default)]`.
  - New snapshots → old code: the unknown `drawn_tile` field is ignored
    by serde's default behavior.
- Calls to `select_action_from_mjai` that omit `tsumogiri` /
  `consumed`, or that target an `Observation` whose `drawn_tile` is
  `None`, transparently fall back to the previous first-match behavior.
- The Python `Observation(...)` / `Observation3P(...)` constructors
  accept the same positional argument list as before; `drawn_tile`
  defaults to `None`.