### PR TITLE
fix: restrict riichi_stage discards to tenpai-maintaining tiles

### DIFF
--- a/riichienv-core/src/state/legal_actions.rs
+++ b/riichienv-core/src/state/legal_actions.rs
@@ -64,17 +64,41 @@ impl GameStateLegalActions for GameState {
             }
 
             // 2. Discard / Riichi
-            let declaration_turn = if self.players[pid_us].riichi_declared {
-                if let Some(idx) = self.players[pid_us].riichi_declaration_index {
-                    self.players[pid_us].discards.len() <= idx
-                } else {
-                    false
+            if self.players[pid_us].riichi_declared {
+                // Post-riichi: only tsumogiri is allowed.
+                if let Some(dt) = self.drawn_tile {
+                    legals.push(Action::new(
+                        ActionType::Discard,
+                        Some(dt),
+                        vec![],
+                        Some(pid),
+                    ));
+                }
+            } else if self.players[pid_us].riichi_stage {
+                // Riichi declared this turn but not yet committed (the Riichi
+                // action came in without a tile, e.g. from an mjai `reach`
+                // event). The follow-up discard must keep the hand tenpai.
+                for &t in self.players[pid_us].hand.iter() {
+                    let is_forbidden = self.players[pid_us]
+                        .forbidden_discards
+                        .iter()
+                        .any(|&f| f / 4 == t / 4);
+                    if is_forbidden {
+                        continue;
+                    }
+                    let mut temp_hand = self.players[pid_us].hand.clone();
+                    if let Some(idx) = temp_hand.iter().position(|&x| x == t) {
+                        temp_hand.remove(idx);
+                    }
+                    let calc = crate::hand_evaluator::HandEvaluator::new(
+                        temp_hand,
+                        self.players[pid_us].melds.clone(),
+                    );
+                    if calc.is_tenpai() {
+                        legals.push(Action::new(ActionType::Discard, Some(t), vec![], Some(pid)));
+                    }
                 }
             } else {
-                false
-            };
-
-            if !self.players[pid_us].riichi_declared || declaration_turn {
                 for &t in self.players[pid_us].hand.iter() {
                     let is_forbidden = self.players[pid_us]
                         .forbidden_discards
@@ -85,17 +109,12 @@ impl GameStateLegalActions for GameState {
                     }
                 }
 
-                // Riichi check (Only if not already declared)
-                if !self.players[pid_us].riichi_declared
-                    && self.players[pid_us].score >= 1000
+                if self.players[pid_us].score >= 1000
                     && self.wall.drawable_count >= 4
                     && self.players[pid_us].melds.iter().all(|m| !m.opened)
-                    && !self.players[pid_us].riichi_stage
                 {
-                    let indices: Vec<usize> = (0..self.players[pid_us].hand.len()).collect();
                     let mut can_riichi = false;
-
-                    for &skip_idx in &indices {
+                    for skip_idx in 0..self.players[pid_us].hand.len() {
                         let mut temp_hand = self.players[pid_us].hand.clone();
                         temp_hand.remove(skip_idx);
                         let calc = crate::hand_evaluator::HandEvaluator::new(
@@ -111,13 +130,6 @@ impl GameStateLegalActions for GameState {
                         legals.push(Action::new(ActionType::Riichi, None, vec![], Some(pid)));
                     }
                 }
-            } else if let Some(dt) = self.drawn_tile {
-                legals.push(Action::new(
-                    ActionType::Discard,
-                    Some(dt),
-                    vec![],
-                    Some(pid),
-                ));
             }
 
             // 3. Kan (Ankan / Kakan)

--- a/riichienv-core/src/state/mod.rs
+++ b/riichienv-core/src/state/mod.rs
@@ -439,10 +439,14 @@ impl GameState {
                         self._trigger_ryukyoku("kyushu_kyuhai");
                     }
                     ActionType::Riichi => {
-                        // Declare Riichi
+                        // Declare Riichi. `!riichi_stage` guards against a
+                        // second Riichi action arriving while the previous
+                        // one is still mid-declaration (between the reach
+                        // event and its committing discard).
                         if self.players[pid as usize].score >= 1000
                             && self.wall.drawable_count >= 4
                             && !self.players[pid as usize].riichi_declared
+                            && !self.players[pid as usize].riichi_stage
                         {
                             self.players[pid as usize].riichi_stage = true;
                             if !self.skip_mjai_logging {

--- a/riichienv-core/src/state/player.rs
+++ b/riichienv-core/src/state/player.rs
@@ -22,7 +22,9 @@ pub struct PlayerState {
     /// (e.g. an mjai `reach` event) and its follow-up `Discard`. While this
     /// flag is set, legal actions must restrict discards to tenpai-maintaining
     /// tiles and must not offer Riichi/Tsumo/Kan/KyushuKyuhai again. The flag
-    /// is cleared (and `riichi_declared` set) inside `_resolve_discard`.
+    /// is cleared (and `riichi_declared` set) when the discard that commits
+    /// the riichi declaration is processed, whether via normal discard
+    /// resolution or replay/log ingestion.
     pub riichi_stage: bool,
 
     pub double_riichi_declared: bool,

--- a/riichienv-core/src/state/player.rs
+++ b/riichienv-core/src/state/player.rs
@@ -12,8 +12,19 @@ pub struct PlayerState {
     pub riichi_declaration_index: Option<usize>,
     pub score: i32,
     pub score_delta: i32,
+
+    /// True after the riichi-declaration discard has been committed (i.e. the
+    /// player is in riichi for the rest of the hand). Mutually exclusive with
+    /// [`Self::riichi_stage`].
     pub riichi_declared: bool,
+
+    /// True only between the `Riichi` action arriving with `tile = None`
+    /// (e.g. an mjai `reach` event) and its follow-up `Discard`. While this
+    /// flag is set, legal actions must restrict discards to tenpai-maintaining
+    /// tiles and must not offer Riichi/Tsumo/Kan/KyushuKyuhai again. The flag
+    /// is cleared (and `riichi_declared` set) inside `_resolve_discard`.
     pub riichi_stage: bool,
+
     pub double_riichi_declared: bool,
     pub missed_agari_riichi: bool,
     pub missed_agari_doujun: bool,

--- a/riichienv-core/src/state_3p/legal_actions.rs
+++ b/riichienv-core/src/state_3p/legal_actions.rs
@@ -67,17 +67,41 @@ impl GameState3PLegalActions for GameState3P {
             }
 
             // 2. Discard / Riichi
-            let declaration_turn = if self.players[pid_us].riichi_declared {
-                if let Some(idx) = self.players[pid_us].riichi_declaration_index {
-                    self.players[pid_us].discards.len() <= idx
-                } else {
-                    false
+            if self.players[pid_us].riichi_declared {
+                // Post-riichi: only tsumogiri is allowed.
+                if let Some(dt) = self.drawn_tile {
+                    legals.push(Action::new(
+                        ActionType::Discard,
+                        Some(dt),
+                        vec![],
+                        Some(pid),
+                    ));
+                }
+            } else if self.players[pid_us].riichi_stage {
+                // Riichi declared this turn but not yet committed (the Riichi
+                // action came in without a tile, e.g. from an mjai `reach`
+                // event). The follow-up discard must keep the hand tenpai.
+                for &t in self.players[pid_us].hand.iter() {
+                    let is_forbidden = self.players[pid_us]
+                        .forbidden_discards
+                        .iter()
+                        .any(|&f| f / 4 == t / 4);
+                    if is_forbidden {
+                        continue;
+                    }
+                    let mut temp_hand = self.players[pid_us].hand.clone();
+                    if let Some(idx) = temp_hand.iter().position(|&x| x == t) {
+                        temp_hand.remove(idx);
+                    }
+                    let calc = crate::hand_evaluator_3p::HandEvaluator3P::new(
+                        temp_hand,
+                        self.players[pid_us].melds.clone(),
+                    );
+                    if calc.is_tenpai() {
+                        legals.push(Action::new(ActionType::Discard, Some(t), vec![], Some(pid)));
+                    }
                 }
             } else {
-                false
-            };
-
-            if !self.players[pid_us].riichi_declared || declaration_turn {
                 for &t in self.players[pid_us].hand.iter() {
                     let is_forbidden = self.players[pid_us]
                         .forbidden_discards
@@ -88,17 +112,12 @@ impl GameState3PLegalActions for GameState3P {
                     }
                 }
 
-                // Riichi check
-                if !self.players[pid_us].riichi_declared
-                    && self.players[pid_us].score >= 1000
+                if self.players[pid_us].score >= 1000
                     && self.wall.drawable_count > 0
                     && self.players[pid_us].melds.iter().all(|m| !m.opened)
-                    && !self.players[pid_us].riichi_stage
                 {
-                    let indices: Vec<usize> = (0..self.players[pid_us].hand.len()).collect();
                     let mut can_riichi = false;
-
-                    for &skip_idx in &indices {
+                    for skip_idx in 0..self.players[pid_us].hand.len() {
                         let mut temp_hand = self.players[pid_us].hand.clone();
                         temp_hand.remove(skip_idx);
                         let calc = crate::hand_evaluator_3p::HandEvaluator3P::new(
@@ -114,13 +133,6 @@ impl GameState3PLegalActions for GameState3P {
                         legals.push(Action::new(ActionType::Riichi, None, vec![], Some(pid)));
                     }
                 }
-            } else if let Some(dt) = self.drawn_tile {
-                legals.push(Action::new(
-                    ActionType::Discard,
-                    Some(dt),
-                    vec![],
-                    Some(pid),
-                ));
             }
 
             // 3. Kan (Ankan / Kakan)

--- a/riichienv-core/src/state_3p/mod.rs
+++ b/riichienv-core/src/state_3p/mod.rs
@@ -399,9 +399,14 @@ impl GameState3P {
                         self._trigger_ryukyoku("kyushu_kyuhai");
                     }
                     ActionType::Riichi => {
+                        // `!riichi_stage` guards against a second Riichi
+                        // action arriving while the previous one is still
+                        // mid-declaration (between the reach event and its
+                        // committing discard).
                         if self.players[pid as usize].score >= 1000
                             && self.wall.drawable_count > 0
                             && !self.players[pid as usize].riichi_declared
+                            && !self.players[pid as usize].riichi_stage
                         {
                             self.players[pid as usize].riichi_stage = true;
                             if !self.skip_mjai_logging {

--- a/riichienv-core/src/state_3p/player.rs
+++ b/riichienv-core/src/state_3p/player.rs
@@ -22,7 +22,9 @@ pub struct PlayerState3P {
     /// (e.g. an mjai `reach` event) and its follow-up `Discard`. While this
     /// flag is set, legal actions must restrict discards to tenpai-maintaining
     /// tiles and must not offer Riichi/Tsumo/Kan/KyushuKyuhai again. The flag
-    /// is cleared (and `riichi_declared` set) inside `_resolve_discard`.
+    /// is cleared (and `riichi_declared` set) when the discard that commits
+    /// the riichi declaration is processed, whether via normal discard
+    /// resolution or replay/log ingestion.
     pub riichi_stage: bool,
 
     pub double_riichi_declared: bool,

--- a/riichienv-core/src/state_3p/player.rs
+++ b/riichienv-core/src/state_3p/player.rs
@@ -12,8 +12,19 @@ pub struct PlayerState3P {
     pub riichi_declaration_index: Option<usize>,
     pub score: i32,
     pub score_delta: i32,
+
+    /// True after the riichi-declaration discard has been committed (i.e. the
+    /// player is in riichi for the rest of the hand). Mutually exclusive with
+    /// [`Self::riichi_stage`].
     pub riichi_declared: bool,
+
+    /// True only between the `Riichi` action arriving with `tile = None`
+    /// (e.g. an mjai `reach` event) and its follow-up `Discard`. While this
+    /// flag is set, legal actions must restrict discards to tenpai-maintaining
+    /// tiles and must not offer Riichi/Tsumo/Kan/KyushuKyuhai again. The flag
+    /// is cleared (and `riichi_declared` set) inside `_resolve_discard`.
     pub riichi_stage: bool,
+
     pub double_riichi_declared: bool,
     pub missed_agari_riichi: bool,
     pub missed_agari_doujun: bool,

--- a/riichienv-core/src/tests.rs
+++ b/riichienv-core/src/tests.rs
@@ -779,12 +779,10 @@ mod unit_tests {
         let pid: u8 = state.current_player;
         let pid_us = pid as usize;
 
-        // 14 tiles, tenpai shape: 123m 456m 789m 12p 11s + drawn 5sr(88)
-        // Discarding 5sr (88) keeps 123456789m 12p 11s tenpai (waits on 3p).
-        // Discarding any of {0,4,8,12,16,20,24,28,32,72,73} would break tenpai.
-        // 36 (1p) keeps tenpai (waits on 1p kanchan? no — keep simple).
-        // Note: removing 36 (1p) leaves 123456789m 2p 11s -> not tenpai.
-        // Only 5sr (88) and 40 (2p) keep tenpai... actually only 88.
+        // 14-tile tenpai fixture: 123m 456m 789m 12p 11s + drawn 5sr (88).
+        // For this hand, discarding 5sr (88) is the intended tenpai-maintaining
+        // discard. Other candidate discards are verified below and must not be
+        // offered unless they also keep the hand in tenpai.
         state.players[pid_us].hand = vec![0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 72, 73, 88];
         state.players[pid_us].hand.sort();
         state.players[pid_us].melds.clear();

--- a/riichienv-core/src/tests.rs
+++ b/riichienv-core/src/tests.rs
@@ -766,6 +766,83 @@ mod unit_tests {
         assert!(state.riichi_pending_acceptance.is_none());
     }
 
+    /// Regression test for #196: when a Riichi action arrives with `tile = None`
+    /// (e.g. converted from an mjai `reach` event), `riichi_stage = true` but
+    /// `riichi_declared = false`. The follow-up discard must be restricted to
+    /// tiles that keep the hand tenpai.
+    #[test]
+    fn test_riichi_stage_only_tenpai_maintaining_discards() {
+        use crate::action::{Action, ActionType};
+        use crate::state::legal_actions::GameStateLegalActions;
+
+        let mut state = create_test_state(2);
+        let pid: u8 = state.current_player;
+        let pid_us = pid as usize;
+
+        // 14 tiles, tenpai shape: 123m 456m 789m 12p 11s + drawn 5sr(88)
+        // Discarding 5sr (88) keeps 123456789m 12p 11s tenpai (waits on 3p).
+        // Discarding any of {0,4,8,12,16,20,24,28,32,72,73} would break tenpai.
+        // 36 (1p) keeps tenpai (waits on 1p kanchan? no — keep simple).
+        // Note: removing 36 (1p) leaves 123456789m 2p 11s -> not tenpai.
+        // Only 5sr (88) and 40 (2p) keep tenpai... actually only 88.
+        state.players[pid_us].hand = vec![0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 72, 73, 88];
+        state.players[pid_us].hand.sort();
+        state.players[pid_us].melds.clear();
+        state.players[pid_us].score = 25000;
+        state.players[pid_us].riichi_declared = false;
+        state.players[pid_us].riichi_stage = false;
+        state.players[pid_us].forbidden_discards.clear();
+        state.drawn_tile = Some(88);
+        state.phase = Phase::WaitAct;
+        state.active_players = vec![pid];
+
+        // Step 1: declare Riichi with tile = None (mjai-style).
+        let mut actions = std::collections::HashMap::new();
+        actions.insert(pid, Action::new(ActionType::Riichi, None, vec![], None));
+        state.step(&actions);
+
+        // After step 1: riichi_stage = true, riichi_declared = false.
+        assert!(state.players[pid_us].riichi_stage);
+        assert!(!state.players[pid_us].riichi_declared);
+
+        // Legal actions must only contain discards that keep the hand tenpai.
+        let legal = state._get_legal_actions_internal(pid);
+        let discard_tiles: Vec<u8> = legal
+            .iter()
+            .filter(|a| a.action_type == ActionType::Discard)
+            .filter_map(|a| a.tile)
+            .collect();
+
+        assert!(
+            !discard_tiles.is_empty(),
+            "At least one tenpai-maintaining discard must be offered"
+        );
+        for &t in &discard_tiles {
+            let mut temp = state.players[pid_us].hand.clone();
+            if let Some(idx) = temp.iter().position(|&x| x == t) {
+                temp.remove(idx);
+            }
+            let calc = crate::hand_evaluator::HandEvaluator::new(
+                temp,
+                state.players[pid_us].melds.clone(),
+            );
+            assert!(
+                calc.is_tenpai(),
+                "Discarding tile {} during riichi_stage must keep the hand tenpai. \
+                 Offered discards: {:?}",
+                t,
+                discard_tiles
+            );
+        }
+
+        // No new Riichi action should be offered while riichi_stage is on.
+        let has_reach = legal.iter().any(|a| a.action_type == ActionType::Riichi);
+        assert!(
+            !has_reach,
+            "Riichi must not be offered again while riichi_stage is true"
+        );
+    }
+
     #[test]
     fn test_no_tobi_with_positive_scores() {
         let mut state = create_test_state(2);


### PR DESCRIPTION
Fixes #196.

The original report attached a game log (`game_0033_seed_50.zip`, East 2nd / step 260) where this manifested as a riichi declared on a hand whose shape was no longer tenpai.

## Fix

- Drop `declaration_turn` and rewrite the discard / riichi branch in `state/legal_actions.rs` and `state_3p/legal_actions.rs` into three explicit cases on the two flags:
  - `riichi_declared` → tsumogiri only.
  - `riichi_stage` → only discards that keep the hand tenpai, checked via `HandEvaluator::is_tenpai` (`HandEvaluator3P` for 3P). `forbidden_discards` is still respected.
  - otherwise → normal discards plus the `Riichi` option when the eligibility conditions are met.
- Add `!riichi_stage` to the inner check of the `ActionType::Riichi` branch in `state/mod.rs` and `state_3p/mod.rs` so the handler's precondition matches the legal-actions guard, even on paths that bypass `step()` validation.
- Add doc comments to `riichi_declared` and `riichi_stage` on `PlayerState` and `PlayerState3P` describing the mutual exclusion and the legal-action restrictions that must hold while `riichi_stage` is set.