### PR TITLE
fix(core): keep abortive draws from ending matches

### DIFF
--- a/riichienv-core/src/state/mod.rs
+++ b/riichienv-core/src/state/mod.rs
@@ -1592,7 +1592,11 @@ impl GameState {
         }
     }
 
-    pub fn _initialize_next_round(&mut self, oya_won: bool, is_draw: bool) {
+    pub fn _initialize_next_round(&mut self, is_renchan: bool, is_draw: bool) {
+        self._advance_round(is_renchan, is_draw, false);
+    }
+
+    fn _advance_round(&mut self, is_renchan: bool, is_draw: bool, is_abortive_draw: bool) {
         if self.is_done {
             return;
         }
@@ -1616,7 +1620,13 @@ impl GameState {
             2 | 5 => self.round_wind == 1 && self.oya == np - 1,
             _ => false,
         };
-        if oya_won && is_last_regular_round && dealer_is_top && dealer_score >= 30000 {
+        // Abortive draws repeat without applying agari-yame or tenpai-yame.
+        if !is_abortive_draw
+            && is_renchan
+            && is_last_regular_round
+            && dealer_is_top
+            && dealer_score >= 30000
+        {
             self._process_end_game();
             return;
         }
@@ -1625,7 +1635,7 @@ impl GameState {
         let mut next_oya = self.oya;
         let mut next_round_wind = self.round_wind;
 
-        if oya_won {
+        if is_renchan {
             next_honba = next_honba.saturating_add(1);
         } else if is_draw {
             next_honba = next_honba.saturating_add(1);
@@ -1645,14 +1655,20 @@ impl GameState {
             1 | 4 => {
                 // TODO: Delete 4, 5, 3
                 let max_score = self.players.iter().map(|p| p.score).max().unwrap_or(0);
-                if next_round_wind >= 1 && (max_score >= 30000 || next_round_wind > 1) {
+                if !is_abortive_draw
+                    && next_round_wind >= 1
+                    && (max_score >= 30000 || next_round_wind > 1)
+                {
                     self._process_end_game();
                     return;
                 }
             }
             2 | 5 => {
                 let max_score = self.players.iter().map(|p| p.score).max().unwrap_or(0);
-                if next_round_wind >= 2 && (max_score >= 30000 || next_round_wind > 2) {
+                if !is_abortive_draw
+                    && next_round_wind >= 2
+                    && (max_score >= 30000 || next_round_wind > 2)
+                {
                     self._process_end_game();
                     return;
                 }
@@ -1964,7 +1980,7 @@ impl GameState {
             self._push_mjai_event(Value::Object(ev));
         }
 
-        self._initialize_next_round(is_renchan, true);
+        self._advance_round(is_renchan, true, reason != "exhaustive_draw");
     }
 
     fn check_abortive_draw(&mut self) -> bool {

--- a/riichienv-core/src/state_3p/mod.rs
+++ b/riichienv-core/src/state_3p/mod.rs
@@ -1498,7 +1498,11 @@ impl GameState3P {
         }
     }
 
-    pub fn _initialize_next_round(&mut self, oya_won: bool, is_draw: bool) {
+    pub fn _initialize_next_round(&mut self, is_renchan: bool, is_draw: bool) {
+        self._advance_round(is_renchan, is_draw, false);
+    }
+
+    fn _advance_round(&mut self, is_renchan: bool, is_draw: bool, is_abortive_draw: bool) {
         if self.is_done {
             return;
         }
@@ -1521,7 +1525,13 @@ impl GameState3P {
             5 => self.round_wind == 1 && self.oya == np - 1,
             _ => false,
         };
-        if oya_won && is_last_regular_round && dealer_is_top && dealer_score >= 40000 {
+        // Abortive draws repeat without applying agari-yame or tenpai-yame.
+        if !is_abortive_draw
+            && is_renchan
+            && is_last_regular_round
+            && dealer_is_top
+            && dealer_score >= 40000
+        {
             self._process_end_game();
             return;
         }
@@ -1530,7 +1540,7 @@ impl GameState3P {
         let mut next_oya = self.oya;
         let mut next_round_wind = self.round_wind;
 
-        if oya_won {
+        if is_renchan {
             next_honba = next_honba.saturating_add(1);
         } else if is_draw {
             next_honba = next_honba.saturating_add(1);
@@ -1550,7 +1560,10 @@ impl GameState3P {
             4 => {
                 // 3p-red-east
                 let max_score = self.players.iter().map(|p| p.score).max().unwrap_or(0);
-                if next_round_wind >= 1 && (max_score >= 40000 || next_round_wind > 1) {
+                if !is_abortive_draw
+                    && next_round_wind >= 1
+                    && (max_score >= 40000 || next_round_wind > 1)
+                {
                     self._process_end_game();
                     return;
                 }
@@ -1558,7 +1571,10 @@ impl GameState3P {
             5 => {
                 // 3p-red-half
                 let max_score = self.players.iter().map(|p| p.score).max().unwrap_or(0);
-                if next_round_wind >= 2 && (max_score >= 40000 || next_round_wind > 2) {
+                if !is_abortive_draw
+                    && next_round_wind >= 2
+                    && (max_score >= 40000 || next_round_wind > 2)
+                {
                     self._process_end_game();
                     return;
                 }
@@ -1854,7 +1870,7 @@ impl GameState3P {
             self._push_mjai_event(Value::Object(ev));
         }
 
-        self._initialize_next_round(is_renchan, true);
+        self._advance_round(is_renchan, true, reason != "exhaustive_draw");
     }
 
     fn check_abortive_draw(&mut self) -> bool {

--- a/riichienv-core/tests/abortive_draw_renchan.rs
+++ b/riichienv-core/tests/abortive_draw_renchan.rs
@@ -1,0 +1,232 @@
+//! Abortive draws must not trigger agari-yame or tenpai-yame (issue #229).
+
+use std::collections::HashMap;
+
+use riichienv_core::action::ActionType;
+use riichienv_core::rule::GameRule;
+use serde_json::{Value, json};
+
+fn events(log: &[String]) -> Vec<Value> {
+    log.iter()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+#[test]
+fn reported_south_4_kyushu_kyuhai_repeats() {
+    use riichienv_core::state::{GameState, legal_actions::GameStateLegalActions};
+
+    // Unmodified final round from the reported game:
+    // https://logs.riichi.dev/mjai-logs/2026/09/08/4ffa7961-4004-4aae-92f9-afa617f48c69.jsonl.gz
+    let reported: Vec<Value> = include_str!("fixtures/issue_229_south_4.jsonl")
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    for rule in [GameRule::default_tenhou(), GameRule::default_mjsoul()] {
+        let mut state = GameState::new(2, false, Some(229), 0, rule);
+        // Restore the opening, then generate the ending through a legal action.
+        for event in &reported[..2] {
+            state.apply_mjai_event(serde_json::from_value(event.clone()).unwrap());
+        }
+        let action = state
+            ._get_legal_actions_internal(3)
+            .into_iter()
+            .find(|action| action.action_type == ActionType::KyushuKyuhai)
+            .expect("the reported declaration must be legal");
+        state.mjai_log.clear();
+        state.step(&HashMap::from([(3, action)]));
+
+        assert!(state.last_error.is_none());
+        assert!(!state.is_done);
+        assert_eq!((state.round_wind, state.oya, state.honba), (1, 3, 1));
+        let generated = events(&state.mjai_log);
+        assert_eq!(generated[..2], reported[2..4]);
+        assert_eq!(generated[2]["type"], "start_kyoku");
+        assert_eq!(generated[2]["bakaze"], "S");
+        assert_eq!(generated[2]["kyoku"], 4);
+        assert_eq!(generated[2]["honba"], 1);
+        assert_eq!(generated[2]["scores"], reported[0]["scores"]);
+        assert_eq!(generated[3]["type"], "tsumo");
+        assert_eq!(generated[3]["actor"], 3);
+        assert_eq!(generated.len(), 4);
+    }
+}
+
+macro_rules! renchan_tests {
+    ($module:ident, $state:ty, $legal:path, $evaluator:ty, $np:expr, $single:expr, $east:expr, $half:expr, $start:expr, $target:expr) => {
+        mod $module {
+            use super::*;
+            use $legal;
+
+            fn state(rule: GameRule, mode: u8, wind: u8, dealer: u8) -> $state {
+                let mut scores = vec![$start; $np];
+                scores[dealer as usize] = $target + 10000;
+                scores[(dealer as usize + 1) % $np] -= $target + 10000 - $start + 1000;
+                let mut state = <$state>::new(mode, false, Some(229), 0, rule);
+                state._initialize_round(dealer, wind, 2, 1, None, Some(scores));
+                state.mjai_log.clear();
+                state
+            }
+
+            fn assert_repeats(mut state: $state, reason: &str) {
+                let before = (state.round_wind, state.oya, state.honba);
+                let scores: Vec<i32> = state.players.iter().map(|p| p.score).collect();
+                state._trigger_ryukyoku(reason);
+                assert!(!state.is_done, "{reason} must repeat at {before:?}");
+                assert_eq!(
+                    (state.round_wind, state.oya, state.honba),
+                    (before.0, before.1, before.2 + 1)
+                );
+                assert_eq!(state.riichi_sticks, 1);
+                let generated = events(&state.mjai_log);
+                assert_eq!(generated[0]["reason"], reason);
+                assert_eq!(generated[0]["deltas"], json!(vec![0; $np]));
+                assert_eq!(generated[1]["type"], "end_kyoku");
+                assert_eq!(generated[2]["type"], "start_kyoku");
+                assert_eq!(generated[2]["scores"], json!(scores));
+                assert_eq!(generated[2]["kyotaku"], 1);
+                assert_eq!(generated[3]["type"], "tsumo");
+                assert_eq!(generated.len(), 4);
+            }
+
+            #[test]
+            fn abortive_draws_repeat_in_orasu_and_extension() {
+                for rule in [GameRule::default_tenhou(), GameRule::default_mjsoul()] {
+                    let mut reasons = vec!["kyushu_kyuhai", "suukansansen"];
+                    if $np == 4 {
+                        reasons.extend(["sufuurenta", "suucha_riichi"]);
+                        if rule.sanchaho_is_draw {
+                            reasons.push("sanchaho");
+                        }
+                    }
+                    for (mode, wind) in [($east, 0), ($half, 1), ($east, 1), ($half, 2)] {
+                        for &reason in &reasons {
+                            // Test the scheduled last round and the extension's
+                            // last dealer; extension must also allow other seats.
+                            assert_repeats(state(rule, mode, wind, $np - 1), reason);
+                            assert_repeats(state(rule, mode, wind, 0), reason);
+                        }
+                    }
+                }
+            }
+
+            #[test]
+            fn kyushu_kyuhai_repeats_regardless_of_declarer_and_dealer_rank() {
+                for actor in [0, $np - 1] {
+                    for dealer_top in [false, true] {
+                        let mut state = state(GameRule::default_tenhou(), $half, 1, $np - 1);
+                        if !dealer_top {
+                            let top = state.players[$np - 1].score;
+                            state.players[$np - 1].score = state.players[0].score;
+                            state.players[0].score = top;
+                        }
+                        // Nine distinct terminals/honors, plus five middle tiles.
+                        state.players[actor as usize].hand =
+                            [0, 8, 9, 17, 18, 26, 27, 28, 29, 10, 11, 12, 13, 14]
+                                .iter()
+                                .map(|t| t * 4 + actor)
+                                .collect();
+                        state.current_player = actor;
+                        state.active_players = vec![actor];
+                        state.drawn_tile = state.players[actor as usize].hand.last().copied();
+                        let action = state
+                            ._get_legal_actions_internal(actor)
+                            .into_iter()
+                            .find(|a| a.action_type == ActionType::KyushuKyuhai)
+                            .expect("fixture must offer kyushu kyuhai");
+                        state.step(&HashMap::from([(actor, action)]));
+                        assert!(state.last_error.is_none());
+                        assert!(!state.is_done);
+                        assert_eq!(state.honba, 3);
+                        assert_eq!(state.oya, $np - 1);
+                    }
+                }
+            }
+
+            #[test]
+            fn exhaustive_draw_still_ends_with_top_tenpai_dealer() {
+                for (mode, wind) in [($east, 0), ($half, 1)] {
+                    let mut state = state(GameRule::default_tenhou(), mode, wind, $np - 1);
+                    for (pid, player) in state.players.iter_mut().enumerate() {
+                        // 123456789p1234s: all players tenpai, so no score changes.
+                        player.hand = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+                            .iter()
+                            .map(|t| t * 4 + pid as u8)
+                            .collect();
+                        player.nagashi_eligible = false;
+                        assert!(<$evaluator>::new(player.hand.clone(), vec![]).is_tenpai());
+                    }
+                    state.wall.drawable_count = 0;
+                    state._deal_next();
+                    assert!(state.is_done);
+                    let generated = events(&state.mjai_log);
+                    assert_eq!(generated[0]["reason"], "exhaustive_draw");
+                    assert_eq!(generated[2]["type"], "end_game");
+                }
+            }
+
+            #[test]
+            fn dealer_win_still_ends_in_orasu() {
+                for (mode, wind) in [($east, 0), ($half, 1)] {
+                    let mut state = state(GameRule::default_tenhou(), mode, wind, $np - 1);
+                    let dealer = $np - 1;
+                    // 123456789p123sEE: a complete closed hand with an East pair.
+                    state.players[dealer as usize].hand =
+                        vec![36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 108, 109];
+                    state.drawn_tile = Some(109);
+                    // Avoid tenhou and bankruptcy masking the agari-yame check.
+                    state.is_first_turn = false;
+                    let action = state
+                        ._get_legal_actions_internal(dealer)
+                        .into_iter()
+                        .find(|a| a.action_type == ActionType::Tsumo)
+                        .expect("fixture must offer tsumo");
+                    state.step(&HashMap::from([(dealer, action)]));
+                    assert!(state.last_error.is_none());
+                    assert!(state.players.iter().all(|p| p.score >= 0));
+                    assert!(state.is_done);
+                    let generated = events(&state.mjai_log);
+                    assert_eq!(generated[0]["type"], "hora");
+                    assert_eq!(generated[2]["type"], "end_game");
+                }
+            }
+
+            #[test]
+            fn single_round_and_bankruptcy_still_end() {
+                let mut single = state(GameRule::default_tenhou(), $single, 0, 0);
+                single._trigger_ryukyoku("kyushu_kyuhai");
+                assert!(single.is_done);
+
+                let mut bankrupt = state(GameRule::default_tenhou(), $half, 1, $np - 1);
+                bankrupt.players[0].score = -1000;
+                bankrupt._trigger_ryukyoku("kyushu_kyuhai");
+                assert!(bankrupt.is_done);
+            }
+        }
+    };
+}
+
+renchan_tests!(
+    four_player,
+    riichienv_core::state::GameState,
+    riichienv_core::state::legal_actions::GameStateLegalActions,
+    riichienv_core::hand_evaluator::HandEvaluator,
+    4,
+    0,
+    1,
+    2,
+    25000,
+    30000
+);
+renchan_tests!(
+    three_player,
+    riichienv_core::state_3p::GameState3P,
+    riichienv_core::state_3p::legal_actions::GameState3PLegalActions,
+    riichienv_core::hand_evaluator_3p::HandEvaluator3P,
+    3,
+    3,
+    4,
+    5,
+    35000,
+    40000
+);

--- a/riichienv-core/tests/fixtures/issue_229_south_4.jsonl
+++ b/riichienv-core/tests/fixtures/issue_229_south_4.jsonl
@@ -1,0 +1,5 @@
+{"bakaze":"S","dora_marker":"3s","honba":0,"kyoku":4,"kyotaku":0,"oya":3,"scores":[6000,34500,14600,44900],"tehais":[["2m","3m","3p","6p","7p","7p","7p","8p","4s","8s","S","F","F"],["5m","9m","1p","1p","5p","6p","6p","2s","5s","6s","N","N","P"],["1m","2m","4m","4m","7m","9m","9m","6s","7s","9s","W","P","F"],["7m","9m","4p","5p","9p","1s","9s","E","W","W","N","P","C"]],"type":"start_kyoku"}
+{"actor":3,"pai":"7m","type":"tsumo"}
+{"deltas":[0,0,0,0],"reason":"kyushu_kyuhai","type":"ryukyoku"}
+{"type":"end_kyoku"}
+{"type":"end_game"}


### PR DESCRIPTION
Preserve dealer repeats after abortive draws in four- and three-player games, including final and extension rounds. Add regression tests using the reported game while preserving normal agari-yame and tenpai-yame behavior.

Fixes #229.