### PR TITLE
fix: retire response claims after calls

### DIFF
--- a/riichienv-core/src/state/mod.rs
+++ b/riichienv-core/src/state/mod.rs
@@ -943,6 +943,10 @@ impl GameState {
                 }
             }
 
+            // Retire this response's offers after recording missed wins and
+            // selecting claims, before a call can open a new response window.
+            self.current_claims.clear();
+
             if !ron_claims.is_empty() {
                 // Sanchaho: all non-discarders ron → abortive draw
                 if ron_claims.len() >= NP - 1 && self.rule.sanchaho_is_draw {
@@ -1296,7 +1300,6 @@ impl GameState {
                 }
             } else {
                 // All Pass
-                self.current_claims.clear();
                 self.active_players.clear();
 
                 if let Some((pk_pid, pk_act)) = self.pending_kan.take() {

--- a/riichienv-core/src/state_3p/mod.rs
+++ b/riichienv-core/src/state_3p/mod.rs
@@ -881,6 +881,10 @@ impl GameState3P {
                 }
             }
 
+            // Retire this response's offers after recording missed wins and
+            // selecting claims, before a call can open a new response window.
+            self.current_claims.clear();
+
             if !ron_claims.is_empty() {
                 let (target_pid, win_tile) = self.last_discard.unwrap_or((self.current_player, 0));
                 ron_claims.sort_by_key(|&pid| (pid + NP as u8 - target_pid) % NP as u8);
@@ -1195,7 +1199,6 @@ impl GameState3P {
                 }
             } else {
                 // All Pass
-                self.current_claims.clear();
                 self.active_players.clear();
 
                 if let Some((pk_pid, pk_act)) = self.pending_kan.take() {

--- a/riichienv-core/tests/claim_lifecycle.rs
+++ b/riichienv-core/tests/claim_lifecycle.rs
@@ -1,0 +1,286 @@
+use riichienv_core::action::{Action, ActionType, Phase};
+use riichienv_core::rule::GameRule;
+use riichienv_core::types::{Meld, MeldType};
+use std::collections::HashMap;
+
+macro_rules! claim_tests {
+    ($name:ident, $state:path, $legal:path, $mode:expr, $np:expr, $rule:expr $(, $kita:ident)?) => {
+        mod $name {
+            use super::*;
+            use $legal;
+            type State = $state;
+
+            fn setup(followup: ActionType) -> State {
+                let mut s = State::new($mode, false, Some(42), 0, $rule);
+                for p in &mut s.players {
+                    p.reset_round();
+                }
+                let draw = match followup {
+                    ActionType::Kakan => {
+                        // 234678p23456s EE: can chi 5p in 4P, but only ron souzu.
+                        s.players[1].hand = vec![40, 44, 48, 56, 60, 64, 76, 80, 84, 89, 92, 108, 109];
+                        s.players[2].melds = vec![Meld::new(
+                            MeldType::Pon, vec![96, 97, 98], true, 0, Some(96),
+                        )];
+                        s.players[0].discards.push(96);
+                        99
+                    }
+                    ActionType::Ankan => {
+                        // Kokushi missing White; can rob an ankan under MjSoul rules.
+                        s.players[1].hand = vec![0, 1, 32, 36, 68, 72, 104, 108, 112, 116, 120, 128, 132];
+                        s.players[2].hand = vec![124, 125, 126];
+                        127
+                    }
+                    ActionType::Kita => {
+                        // Six pairs and a singleton North.
+                        s.players[1].hand = vec![40, 41, 44, 45, 60, 61, 72, 73, 80, 81, 108, 109, 120];
+                        123
+                    }
+                    _ => unreachable!(),
+                };
+                s.players[2].hand.extend([53, 54, 55]);
+                let reserved: Vec<_> = s.players.iter()
+                    .flat_map(|p| {
+                        p.hand.iter().copied()
+                            .chain(p.melds.iter().flat_map(|m| m.tiles.iter().copied()))
+                    })
+                    .chain([52, draw, 119])
+                    .collect();
+                let mut pool: Vec<u8> = (0..136)
+                    .filter(|t| !reserved.contains(t) && ($np == 4 || *t < 4 || *t >= 32))
+                    .collect();
+                for p in &mut s.players {
+                    let missing = 13 - 3 * p.melds.len() - p.hand.len();
+                    p.hand.extend(pool.drain(..missing));
+                }
+                s.players[0].hand.push(52);
+                pool.splice(..0, [draw, 119]);
+                // load_wall also initializes the 3P dora/ura indicator arrays.
+                s.wall.load_wall(pool.into_iter().rev().collect());
+                s.wall.drawable_count = (s.wall.tiles.len() - 14) as u8;
+                s.current_player = 0;
+                s.active_players = vec![0];
+                s.drawn_tile = Some(52);
+                s.is_first_turn = false;
+                s.phase = Phase::WaitAct;
+                s.current_claims.clear();
+                assert_inventory(&s);
+                s
+            }
+
+            fn assert_inventory(s: &State) {
+                let meld_tiles: Vec<_> = s.players.iter()
+                    .flat_map(|p| p.melds.iter().flat_map(|m| m.tiles.iter().copied()))
+                    .collect();
+                let mut tiles: Vec<_> = s.wall.tiles.iter().copied()
+                    .chain(meld_tiles.iter().copied())
+                    .chain(s.players.iter().flat_map(|p| {
+                        p.hand.iter().chain(&p.kita_tiles)
+                            .chain(p.discards.iter().filter(|t| !meld_tiles.contains(t)))
+                            .copied()
+                    }))
+                    .collect();
+                tiles.sort();
+                let expected: Vec<u8> = (0..136)
+                    .filter(|t| $np == 4 || *t < 4 || *t >= 32)
+                    .collect();
+                assert_eq!(tiles, expected);
+            }
+
+            fn legal(s: &State, pid: u8, kind: ActionType) -> Action {
+                s._get_legal_actions_internal(pid).into_iter()
+                    .find(|a| {
+                        // Select the White kan completed by the replacement draw.
+                        a.action_type == kind
+                            && (kind != ActionType::Ankan || a.consume_tiles.contains(&127))
+                    })
+                    .unwrap()
+            }
+
+            fn act(s: &mut State, pid: u8, kind: ActionType) {
+                let mut actions = HashMap::from([(pid, legal(s, pid, kind))]);
+                if s.phase == Phase::WaitResponse {
+                    for &other in &s.active_players {
+                        actions.entry(other).or_insert_with(|| {
+                            Action::new(ActionType::Pass, None, vec![], Some(other))
+                        });
+                    }
+                }
+                s.step(&actions);
+                assert_eq!(s.last_error, None);
+                assert_inventory(s);
+            }
+
+            fn discard(s: &mut State) {
+                s.step(&HashMap::from([(
+                    0, Action::new(ActionType::Discard, Some(52), vec![], Some(0)),
+                )]));
+                assert_eq!(s.phase, Phase::WaitResponse);
+                assert_eq!(s.last_error, None);
+                assert_inventory(s);
+            }
+
+            fn after_daiminkan(followup: ActionType) -> State {
+                let mut s = setup(followup);
+                discard(&mut s);
+                act(&mut s, 2, ActionType::Daiminkan);
+                s
+            }
+
+            fn assert_ron_only(s: &mut State, pid: u8) {
+                assert_eq!(s.phase, Phase::WaitResponse);
+                assert_eq!(s.active_players, vec![pid]);
+                let tile = s.last_discard.unwrap().1;
+                for other in 0..$np {
+                    let actions: Vec<Action> = s.get_observation(other)
+                        .legal_actions_method().into_iter().map(Action::from).collect();
+                    if other == pid {
+                        assert_eq!(actions.len(), 2);
+                        assert!(actions.iter().any(|a| {
+                            a.action_type == ActionType::Ron && a.tile == Some(tile)
+                        }));
+                        assert!(actions.iter().any(|a| a.action_type == ActionType::Pass));
+                    } else {
+                        assert!(actions.is_empty());
+                        assert!(s._get_legal_actions_internal(other).iter()
+                            .all(|a| a.action_type == ActionType::Pass));
+                    }
+                }
+            }
+
+            #[test]
+            fn accepting_pon_or_daiminkan_retires_discard_offers() {
+                for kind in [ActionType::Pon, ActionType::Daiminkan] {
+                    let mut s = setup(ActionType::Kakan);
+                    discard(&mut s);
+                    act(&mut s, 2, kind);
+                    assert_eq!(s.phase, Phase::WaitAct);
+                    assert_eq!(s.active_players, vec![2]);
+                    assert!(s.current_claims.is_empty());
+                }
+            }
+
+            #[test]
+            fn kakan_offers_only_current_ron_and_resolves_ron_or_pass() {
+                for response in [ActionType::Ron, ActionType::Pass] {
+                    let mut s = after_daiminkan(ActionType::Kakan);
+                    act(&mut s, 2, ActionType::Kakan);
+                    assert_ron_only(&mut s, 1);
+                    assert_eq!(s.wall.rinshan_draw_count, 1);
+                    act(&mut s, 1, response);
+                    assert!(s.current_claims.is_empty());
+                    if response == ActionType::Ron {
+                        assert!(s.is_done);
+                        assert!(s.win_results.contains_key(&1));
+                        assert_eq!(s.wall.rinshan_draw_count, 1);
+                    } else {
+                        assert!(!s.is_done);
+                        assert_eq!(s.phase, Phase::WaitAct);
+                        assert_eq!(s.current_player, 2);
+                        assert_eq!(s.drawn_tile, Some(119));
+                        assert_eq!(s.wall.rinshan_draw_count, 2);
+                        assert!(s.players[1].missed_agari_doujun);
+                    }
+                }
+            }
+
+            #[test]
+            fn submitting_a_stale_call_cannot_duplicate_tiles() {
+                let mut s = setup(ActionType::Kakan);
+                discard(&mut s);
+                let pid = if $np == 4 { 1 } else { 2 };
+                let kind = if $np == 4 {
+                    ActionType::Chi
+                } else {
+                    ActionType::Daiminkan
+                };
+                let stale = legal(&s, pid, kind);
+                act(&mut s, 2, ActionType::Daiminkan);
+                act(&mut s, 2, ActionType::Kakan);
+                let mut actions = HashMap::from([(pid, stale)]);
+                actions.entry(1).or_insert_with(|| {
+                    Action::new(ActionType::Pass, None, vec![], Some(1))
+                });
+                s.step(&actions);
+                assert_eq!(
+                    s.last_error,
+                    Some(format!("Error: Illegal Action by Player {pid}")),
+                );
+                assert_inventory(&s);
+            }
+
+            #[test]
+            fn ankan_does_not_restore_old_discard_offers() {
+                let mut s = after_daiminkan(ActionType::Ankan);
+                act(&mut s, 2, ActionType::Ankan);
+                if s.rule.allows_ron_on_ankan_for_kokushi_musou {
+                    assert_ron_only(&mut s, 1);
+                    act(&mut s, 1, ActionType::Pass);
+                    assert!(s.players[1].missed_agari_doujun);
+                }
+                assert_eq!(s.phase, Phase::WaitAct);
+                assert!(s.current_claims.is_empty());
+                assert_eq!(s.wall.rinshan_draw_count, 2);
+                assert_inventory(&s);
+            }
+
+            $(claim_tests!(@kita_test $kita);)?
+        }
+    };
+    (@kita_test $kita:ident) => {
+        #[test]
+        fn kita_offers_only_current_ron_and_resolves_ron_or_pass() {
+            for response in [ActionType::Ron, ActionType::Pass] {
+                let mut s = after_daiminkan(ActionType::Kita);
+                act(&mut s, 2, ActionType::Kita);
+                assert_ron_only(&mut s, 1);
+                act(&mut s, 1, response);
+                assert!(s.current_claims.is_empty());
+                if response == ActionType::Ron {
+                    assert!(s.is_done);
+                    assert!(s.win_results.contains_key(&1));
+                } else {
+                    assert_eq!(s.phase, Phase::WaitAct);
+                    assert_eq!(s.drawn_tile, Some(119));
+                    assert_eq!(s.wall.rinshan_draw_count, 2);
+                    assert!(s.players[1].missed_agari_doujun);
+                }
+            }
+        }
+    };
+}
+
+claim_tests!(
+    tenhou_4p,
+    riichienv_core::state::GameState,
+    riichienv_core::state::legal_actions::GameStateLegalActions,
+    0,
+    4,
+    GameRule::default_tenhou()
+);
+claim_tests!(
+    mjsoul_4p,
+    riichienv_core::state::GameState,
+    riichienv_core::state::legal_actions::GameStateLegalActions,
+    0,
+    4,
+    GameRule::default_mjsoul()
+);
+claim_tests!(
+    tenhou_3p,
+    riichienv_core::state_3p::GameState3P,
+    riichienv_core::state_3p::legal_actions::GameState3PLegalActions,
+    3,
+    3,
+    GameRule::default_tenhou(),
+    kita
+);
+claim_tests!(
+    mjsoul_3p,
+    riichienv_core::state_3p::GameState3P,
+    riichienv_core::state_3p::legal_actions::GameState3PLegalActions,
+    3,
+    3,
+    GameRule::default_mjsoul(),
+    kita
+);

--- a/tests/env/actions/test_claim_lifecycle.py
+++ b/tests/env/actions/test_claim_lifecycle.py
@@ -1,0 +1,97 @@
+"""Reach daiminkan -> kakan from a complete wall through legal actions only."""
+
+import pytest
+
+from riichienv import Action, ActionType, GameRule, Phase, RiichiEnv
+
+
+def assert_inventory(env):
+    meld_tiles = [tile for melds in env.melds for meld in melds for tile in meld.tiles]
+    tiles = env.wall + meld_tiles + [tile for hand in env.hands for tile in hand]
+    tiles += [tile for discards in env.discards for tile in discards if tile not in meld_tiles]
+    assert sorted(tiles) == list(range(136))
+
+
+def reach_chankan(rule):
+    # P1 starts one tile short of 234p234m23456s EE, a souzu wait.
+    ready = [40, 44, 48, 4, 8, 12, 89, 92, 76, 80, 84, 108, 109]
+    hands = [[], [t for t in ready if t != 48] + [132], [], []]
+    reserved = set(hands[1] + [36, 37, 38, 39, 96, 97, 98, 99, 48, 0, 1, 2, 3, 120])
+    pool = [t for t in range(136) if t not in reserved]
+    hands[2] = [37, 38, 39, 97, 98] + pool[:8]
+    del pool[:8]
+    discard_after_pon = hands[2][-1]
+    hands[0] = [96] + pool[:12]
+    del pool[:12]
+    hands[3] = pool[:13]
+    del pool[:13]
+    deal = [t for start in (0, 4, 8) for hand in hands for t in hand[start : start + 4]]
+    deal.extend(hand[12] for hand in hands)
+    wall = deal + [120, 0, 1, 48, 2, 3, 36] + pool + [99]
+    assert sorted(wall) == list(range(136))
+    env = RiichiEnv("4p-red-single", seed=42, rule=rule)
+    env.reset(wall=wall, oya=0)
+
+    def step(actions):
+        observations = env.step(actions)
+        assert not env.is_done
+        assert observations
+        assert_inventory(env)
+
+    def discard(pid, tile):
+        if env.phase == Phase.WaitResponse:
+            step({p: Action(ActionType.PASS) for p in env.active_players})
+        assert env.current_player == pid
+        action = next(a for a in env._get_legal_actions(pid) if a.action_type == ActionType.DISCARD and a.tile == tile)
+        step({pid: action})
+
+    def call(pid, kind):
+        action = next(a for a in env._get_legal_actions(pid) if a.action_type == kind)
+        step({p: action if p == pid else Action(ActionType.PASS) for p in env.active_players})
+
+    discard(0, 96)
+    call(2, ActionType.PON)
+    discard(2, discard_after_pon)
+    discard(3, 0)
+    discard(0, 1)
+    discard(1, 132)  # P1 drew 4p and is now waiting on souzu.
+    discard(2, 2)
+    discard(3, 3)
+    discard(0, 36)
+    stale_chi = next(a for a in env._get_legal_actions(1) if a.action_type == ActionType.CHI)
+    assert not any(a.action_type == ActionType.RON for a in env._get_legal_actions(1))
+    call(2, ActionType.DAIMINKAN)
+    assert env.drawn_tile == 99
+    kakan = next(a for a in env._get_legal_actions(2) if a.action_type == ActionType.KAKAN and a.tile == 99)
+    step({2: kakan})
+    assert env.phase == Phase.WaitResponse
+    assert env.active_players == [1]
+    return env, stale_chi
+
+
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+def test_chankan_offers_only_current_actions(preset):
+    env, _ = reach_chankan(getattr(GameRule, f"default_{preset}")())
+    actions = env.get_observation(1).legal_actions()
+    assert {a.action_type for a in actions} == {ActionType.RON, ActionType.PASS}
+    for action in actions:
+        alternate = env.clone()
+        alternate.step({1: action})
+        assert_inventory(alternate)
+        if action.action_type == ActionType.RON:
+            assert alternate.is_done
+            assert 1 in alternate.win_results
+        else:
+            assert not alternate.is_done
+            assert alternate.phase == Phase.WaitAct
+            assert alternate.current_player == 2
+            assert alternate.rinshan_draw_count == 2
+            assert alternate.missed_agari_doujun[1]
+
+
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+def test_stale_chi_is_rejected_without_duplicating_tiles(preset):
+    env, stale_chi = reach_chankan(getattr(GameRule, f"default_{preset}")())
+    env.step({1: stale_chi})
+    assert_inventory(env)
+    assert any(e.get("reason") == "Error: Illegal Action by Player 1" for e in env.mjai_log)


### PR DESCRIPTION
Clear resolved response claims to prevent stale call options from surviving into subsequent kan or kita responses and creating invalid melds or duplicate tiles.