### PR TITLE
fix: correct yakuman scoring for special hands

### DIFF
--- a/riichienv-core/src/yaku.rs
+++ b/riichienv-core/src/yaku.rs
@@ -234,24 +234,47 @@ pub fn calculate_yaku(hand: &Hand, melds: &[Meld], ctx: &YakuContext, win_tile: 
     let mut best_res = YakuResult::default();
 
     if divisions.is_empty() {
-        if agari::is_kokushi(hand) {
+        let kokushi = agari::is_kokushi(hand);
+        let chiitoitsu = agari::is_chiitoitsu(hand);
+        if !kokushi && !chiitoitsu {
+            return best_res;
+        }
+
+        // Special hands can also have Tenhou/Chiihou or all-honors yakuman.
+        // Evaluate those before adding either Kokushi or ordinary seven-pairs yaku.
+        apply_yakuman(
+            &mut best_res,
+            hand,
+            melds,
+            ctx,
+            &Division {
+                head: 0,
+                body: Vec::new(),
+            },
+            None,
+            win_tile,
+        );
+        if kokushi {
             let is_13_wait = hand.counts[win_tile as usize] == 2;
             if is_13_wait {
-                best_res.han = 26;
-                best_res.yakuman_count = 2;
+                best_res.han += 26;
+                best_res.yakuman_count += 2;
                 best_res.yaku_ids.push(ID_KOKUSHI_13);
                 best_res
                     .yaku_names
                     .push("Kokushi Musou 13-wait".to_string());
             } else {
-                best_res.han = 13;
-                best_res.yakuman_count = 1;
+                best_res.han += 13;
+                best_res.yakuman_count += 1;
                 best_res.yaku_ids.push(ID_KOKUSHI);
                 best_res.yaku_names.push("Kokushi Musou".to_string());
             }
             return best_res;
         }
-        if agari::is_chiitoitsu(hand) {
+        if chiitoitsu {
+            if best_res.yakuman_count > 0 {
+                return best_res;
+            }
             best_res.han = 2;
             best_res.fu = 25;
             best_res.yaku_ids.push(ID_CHITOITSU);
@@ -277,18 +300,6 @@ pub fn calculate_yaku(hand: &Hand, melds: &[Meld], ctx: &YakuContext, win_tile: 
                 best_res.yaku_names.push("Honroutou".to_string());
             }
 
-            apply_yakuman(
-                &mut best_res,
-                hand,
-                melds,
-                ctx,
-                &Division {
-                    head: 0,
-                    body: Vec::new(),
-                },
-                None,
-                win_tile,
-            ); // Simplified call
             apply_static_yaku(&mut best_res, ctx);
             return best_res;
         }

--- a/riichienv-core/src/yaku.rs
+++ b/riichienv-core/src/yaku.rs
@@ -255,7 +255,11 @@ pub fn calculate_yaku(hand: &Hand, melds: &[Meld], ctx: &YakuContext, win_tile: 
             win_tile,
         );
         if kokushi {
-            let is_13_wait = hand.counts[win_tile as usize] == 2;
+            // The Tenhou yaku has no distinguished winning tile among the initial 14:
+            // use the thirteen-sided interpretation regardless of dealing order.
+            // GameRule still caps this pattern when double yakuman is disabled.
+            let is_13_wait =
+                best_res.yaku_ids.contains(&ID_TENHO) || hand.counts[win_tile as usize] == 2;
             if is_13_wait {
                 best_res.han += 26;
                 best_res.yakuman_count += 2;

--- a/riichienv-core/src/yaku_3p.rs
+++ b/riichienv-core/src/yaku_3p.rs
@@ -86,7 +86,11 @@ pub fn calculate_yaku_3p(
             win_tile,
         );
         if kokushi {
-            let is_13_wait = hand.counts[win_tile as usize] == 2;
+            // The Tenhou yaku has no distinguished winning tile among the initial 14:
+            // use the thirteen-sided interpretation regardless of dealing order.
+            // GameRule still caps this pattern when double yakuman is disabled.
+            let is_13_wait =
+                best_res.yaku_ids.contains(&ID_TENHO) || hand.counts[win_tile as usize] == 2;
             if is_13_wait {
                 best_res.han += 26;
                 best_res.yakuman_count += 2;

--- a/riichienv-core/src/yaku_3p.rs
+++ b/riichienv-core/src/yaku_3p.rs
@@ -65,24 +65,47 @@ pub fn calculate_yaku_3p(
     let mut best_res = YakuResult::default();
 
     if divisions.is_empty() {
-        if agari::is_kokushi(hand) {
+        let kokushi = agari::is_kokushi(hand);
+        let chiitoitsu = agari::is_chiitoitsu(hand);
+        if !kokushi && !chiitoitsu {
+            return best_res;
+        }
+
+        // Special hands can also have Tenhou/Chiihou or all-honors yakuman.
+        // Evaluate those before adding either Kokushi or ordinary seven-pairs yaku.
+        apply_yakuman(
+            &mut best_res,
+            hand,
+            melds,
+            ctx,
+            &Division {
+                head: 0,
+                body: Vec::new(),
+            },
+            None,
+            win_tile,
+        );
+        if kokushi {
             let is_13_wait = hand.counts[win_tile as usize] == 2;
             if is_13_wait {
-                best_res.han = 26;
-                best_res.yakuman_count = 2;
+                best_res.han += 26;
+                best_res.yakuman_count += 2;
                 best_res.yaku_ids.push(ID_KOKUSHI_13);
                 best_res
                     .yaku_names
                     .push("Kokushi Musou 13-wait".to_string());
             } else {
-                best_res.han = 13;
-                best_res.yakuman_count = 1;
+                best_res.han += 13;
+                best_res.yakuman_count += 1;
                 best_res.yaku_ids.push(ID_KOKUSHI);
                 best_res.yaku_names.push("Kokushi Musou".to_string());
             }
             return best_res;
         }
-        if agari::is_chiitoitsu(hand) {
+        if chiitoitsu {
+            if best_res.yakuman_count > 0 {
+                return best_res;
+            }
             best_res.han = 2;
             best_res.fu = 25;
             best_res.yaku_ids.push(ID_CHITOITSU);
@@ -108,18 +131,6 @@ pub fn calculate_yaku_3p(
                 best_res.yaku_names.push("Honroutou".to_string());
             }
 
-            apply_yakuman(
-                &mut best_res,
-                hand,
-                melds,
-                ctx,
-                &Division {
-                    head: 0,
-                    body: Vec::new(),
-                },
-                None,
-                win_tile,
-            );
             apply_static_yaku(&mut best_res, ctx);
             return best_res;
         }

--- a/riichienv-core/tests/special_hand_yakuman.rs
+++ b/riichienv-core/tests/special_hand_yakuman.rs
@@ -55,6 +55,13 @@ macro_rules! special_hand_tests {
                         } else {
                             ID_CHIHO
                         };
+                        // Tenhou uses all 14 initial tiles, so Kokushi is always
+                        // interpreted as thirteen-sided regardless of the last dealt tile.
+                        let (units, id) = if wind == Wind::East {
+                            (2, ID_KOKUSHI_13)
+                        } else {
+                            (units, id)
+                        };
                         assert_yaku(&result, 13 * (units + 1), &[id, heavenly]);
                         assert!(result.yakuman);
                         assert_eq!(result.fu, 0);
@@ -67,6 +74,28 @@ macro_rules! special_hand_tests {
                             assert_eq!(result.tsumo_agari_oya, base * 2 + 200);
                         }
                     }
+                }
+            }
+
+            #[test]
+            fn tenhou_kokushi_is_independent_of_the_designated_winning_tile() {
+                let evaluator = Evaluator::hand_from_text("119m19p19s1234567z").unwrap();
+                for tile in [0, 1, 32, 36, 68, 72, 104, 108, 112, 116, 120, 124, 128, 132] {
+                    let result = evaluator.calc(
+                        tile,
+                        vec![],
+                        vec![],
+                        Some(Conditions {
+                            tsumo: true,
+                            tsumo_first_turn: true,
+                            player_wind: Wind::East,
+                            is_sanma: $players == 3,
+                            num_players: $players,
+                            ..Default::default()
+                        }),
+                    );
+                    assert_yaku(&result, 39, &[ID_TENHO, ID_KOKUSHI_13]);
+                    assert_eq!(result.tsumo_agari_ko, 48000);
                 }
             }
 

--- a/riichienv-core/tests/special_hand_yakuman.rs
+++ b/riichienv-core/tests/special_hand_yakuman.rs
@@ -1,0 +1,285 @@
+use riichienv_core::types::{Conditions, WinResult, Wind};
+use riichienv_core::yaku::*;
+
+fn assert_yaku(result: &WinResult, han: u32, expected: &[u32]) {
+    assert!(result.is_win);
+    assert_eq!(result.han, han);
+    let mut actual = result.yaku.clone();
+    let mut expected = expected.to_vec();
+    actual.sort();
+    expected.sort();
+    assert_eq!(actual, expected);
+}
+
+macro_rules! special_hand_tests {
+    ($name:ident, $evaluator:path, $players:expr) => {
+        mod $name {
+            use super::*;
+            type Evaluator = $evaluator;
+
+            fn calc(text: &str, tile: u8, mut conditions: Conditions, bonus: bool) -> WinResult {
+                conditions.is_sanma = $players == 3;
+                conditions.num_players = $players;
+                // For 224466p2205668s: two 4p dora, two 6p ura, and a red 5s.
+                let (dora, ura) = if bonus {
+                    (vec![44], vec![52])
+                } else {
+                    (vec![], vec![])
+                };
+                Evaluator::hand_from_text(text)
+                    .unwrap()
+                    .calc(tile, dora, ura, Some(conditions))
+            }
+
+            #[test]
+            fn kokushi_stacks_with_tenhou_and_chiihou() {
+                for (text, tile, units, id) in [
+                    ("119m19p19s123467z", 124, 1, ID_KOKUSHI),
+                    ("19m19p19s1234567z", 1, 2, ID_KOKUSHI_13),
+                ] {
+                    for wind in [Wind::East, Wind::South] {
+                        let result = calc(
+                            text,
+                            tile,
+                            Conditions {
+                                tsumo: true,
+                                tsumo_first_turn: true,
+                                player_wind: wind,
+                                honba: 2,
+                                ..Default::default()
+                            },
+                            false,
+                        );
+                        let heavenly = if wind == Wind::East {
+                            ID_TENHO
+                        } else {
+                            ID_CHIHO
+                        };
+                        assert_yaku(&result, 13 * (units + 1), &[id, heavenly]);
+                        assert!(result.yakuman);
+                        assert_eq!(result.fu, 0);
+                        let base = 8000 * (units + 1);
+                        assert_eq!(
+                            result.tsumo_agari_ko,
+                            base * if wind == Wind::East { 2 } else { 1 } + 200
+                        );
+                        if wind == Wind::South {
+                            assert_eq!(result.tsumo_agari_oya, base * 2 + 200);
+                        }
+                    }
+                }
+            }
+
+            #[test]
+            fn kokushi_later_tsumo_and_ron_do_not_get_heavenly_yaku() {
+                for (text, tile, units, id) in [
+                    ("119m19p19s123467z", 124, 1, ID_KOKUSHI),
+                    ("19m19p19s1234567z", 1, 2, ID_KOKUSHI_13),
+                ] {
+                    for tsumo in [false, true] {
+                        let result = calc(
+                            text,
+                            tile,
+                            Conditions {
+                                tsumo,
+                                tsumo_first_turn: !tsumo,
+                                player_wind: Wind::South,
+                                ..Default::default()
+                            },
+                            false,
+                        );
+                        assert_yaku(&result, 13 * units, &[id]);
+                        assert!(result.yakuman);
+                        if tsumo {
+                            assert_eq!(result.tsumo_agari_oya, 16000 * units);
+                            assert_eq!(result.tsumo_agari_ko, 8000 * units);
+                        } else {
+                            assert_eq!(result.ron_agari, 32000 * units);
+                        }
+                    }
+                }
+            }
+
+            #[test]
+            fn heavenly_seven_pairs_excludes_ordinary_yaku_and_dora() {
+                for wind in [Wind::East, Wind::South] {
+                    let result = calc(
+                        "224466p2205668s",
+                        101,
+                        Conditions {
+                            tsumo: true,
+                            tsumo_first_turn: true,
+                            player_wind: wind,
+                            ..Default::default()
+                        },
+                        true,
+                    );
+                    assert_yaku(
+                        &result,
+                        13,
+                        &[if wind == Wind::East {
+                            ID_TENHO
+                        } else {
+                            ID_CHIHO
+                        }],
+                    );
+                    assert!(result.yakuman);
+                    assert_eq!(result.fu, 0);
+                }
+            }
+
+            #[test]
+            fn all_honors_seven_pairs_excludes_riichi_and_all_bonus_tiles() {
+                for tsumo in [false, true] {
+                    let result = Evaluator::hand_from_text("1122334455667z").unwrap().calc(
+                        133,
+                        vec![118],
+                        vec![119],
+                        Some(Conditions {
+                            tsumo,
+                            riichi: true,
+                            player_wind: Wind::South,
+                            // The two Norths outside the hand can be extracted in 3P.
+                            kita_count: if $players == 3 { 2 } else { 0 },
+                            is_sanma: $players == 3,
+                            num_players: $players,
+                            ..Default::default()
+                        }),
+                    );
+                    assert_yaku(&result, 13, &[ID_TSUISO]);
+                    assert!(result.yakuman);
+                    assert_eq!(result.fu, 0);
+                    if tsumo {
+                        assert_eq!(result.tsumo_agari_oya, 16000);
+                        assert_eq!(result.tsumo_agari_ko, 8000);
+                    } else {
+                        assert_eq!(result.ron_agari, 32000);
+                    }
+                }
+            }
+
+            #[test]
+            fn many_dora_cannot_turn_all_honors_into_multiple_yakuman() {
+                let result = Evaluator::hand_from_text("1122334455667z").unwrap().calc(
+                    133,
+                    vec![110, 114, 118, 122, 126],
+                    vec![111, 115, 119, 123, 127],
+                    Some(Conditions {
+                        riichi: true,
+                        player_wind: Wind::South,
+                        is_sanma: $players == 3,
+                        num_players: $players,
+                        ..Default::default()
+                    }),
+                );
+                // Ten dora and ten ura must not inflate a single all-honors yakuman.
+                assert_eq!(result.ron_agari, 32000);
+                assert_yaku(&result, 13, &[ID_TSUISO]);
+                assert!(result.yakuman);
+            }
+
+            #[test]
+            fn all_honors_seven_pairs_stacks_with_heavenly_yaku() {
+                for wind in [Wind::East, Wind::South] {
+                    let result = calc(
+                        "1122334455667z",
+                        133,
+                        Conditions {
+                            tsumo: true,
+                            tsumo_first_turn: true,
+                            player_wind: wind,
+                            ..Default::default()
+                        },
+                        false,
+                    );
+                    assert_yaku(
+                        &result,
+                        26,
+                        &[
+                            ID_TSUISO,
+                            if wind == Wind::East {
+                                ID_TENHO
+                            } else {
+                                ID_CHIHO
+                            },
+                        ],
+                    );
+                    assert!(result.yakuman);
+                    assert_eq!(result.fu, 0);
+                }
+            }
+
+            #[test]
+            fn ordinary_seven_pairs_keeps_yaku_dora_and_25_fu() {
+                let result = calc(
+                    "224466p2205668s",
+                    101,
+                    Conditions {
+                        tsumo: true,
+                        riichi: true,
+                        player_wind: Wind::South,
+                        kita_count: if $players == 3 { 2 } else { 0 },
+                        ..Default::default()
+                    },
+                    true,
+                );
+                let mut expected = vec![
+                    ID_CHITOITSU,
+                    ID_TANYAO,
+                    ID_TSUMO,
+                    ID_RIICHI,
+                    ID_DORA,
+                    ID_URADORA,
+                    ID_AKADORA,
+                ];
+                if $players == 3 {
+                    expected.push(ID_NUKIDORA);
+                }
+                assert_yaku(&result, if $players == 3 { 12 } else { 10 }, &expected);
+                assert!(!result.yakuman);
+                assert_eq!(result.fu, 25);
+                assert_eq!(
+                    result.tsumo_agari_oya,
+                    if $players == 3 { 12000 } else { 8000 }
+                );
+            }
+
+            #[test]
+            fn kazoe_seven_pairs_remains_a_single_counted_yakuman() {
+                let result = Evaluator::hand_from_text("224466p2205668s").unwrap().calc(
+                    101,
+                    vec![44, 45, 46, 47],
+                    vec![52],
+                    Some(Conditions {
+                        tsumo: true,
+                        riichi: true,
+                        player_wind: Wind::South,
+                        kita_count: if $players == 3 { 2 } else { 0 },
+                        is_sanma: $players == 3,
+                        num_players: $players,
+                        ..Default::default()
+                    }),
+                );
+                assert!(result.is_win);
+                assert!(!result.yakuman);
+                assert_eq!(result.han, if $players == 3 { 18 } else { 16 });
+                assert_eq!(result.fu, 25);
+                assert!(result.yaku.contains(&ID_CHITOITSU));
+                assert!(result.yaku.iter().all(|&id| id < ID_TENHO));
+                assert_eq!(result.tsumo_agari_oya, 16000);
+                assert_eq!(result.tsumo_agari_ko, 8000);
+            }
+        }
+    };
+}
+
+special_hand_tests!(
+    four_player,
+    riichienv_core::hand_evaluator::HandEvaluator,
+    4
+);
+special_hand_tests!(
+    three_player,
+    riichienv_core::hand_evaluator_3p::HandEvaluator3P,
+    3
+);

--- a/tests/env/agari/test_special_hand_yakuman.py
+++ b/tests/env/agari/test_special_hand_yakuman.py
@@ -13,8 +13,13 @@ HANDS = {
 }
 
 
-def setup_wall(players, winner, kind, first_turn):
-    hand, winning_tile = HANDS[kind]
+def setup_wall(players, winner, kind, first_turn, winning_tile=None):
+    hand, default_tile = HANDS[kind]
+    if winning_tile is None:
+        winning_tile = default_tile
+    else:
+        hand = hand + [default_tile]
+        hand.remove(winning_tile)
     all_tiles = [t for t in range(136) if players == 4 or t < 4 or t >= 32]
     # 6p indicates 7p, absent from every test hand. Keep it in the dead wall.
     indicator = 56
@@ -79,8 +84,9 @@ def test_special_hand_yakuman_payments(players, preset, winner, kind, first_turn
     units = int(first_turn)
     expected_yaku = [35 if winner == 0 else 36] if first_turn else []
     if kind in ("kokushi", "kokushi_13"):
-        units += 1 + int(kind == "kokushi_13" and preset == "mjsoul")
-        expected_yaku.append(42 if kind == "kokushi" else 49)
+        thirteen_sided = kind == "kokushi_13" or (first_turn and winner == 0)
+        units += 1 + int(thirteen_sided and preset == "mjsoul")
+        expected_yaku.append(49 if thirteen_sided else 42)
     elif kind == "all_honors":
         units += 1
         expected_yaku.append(39)
@@ -100,3 +106,26 @@ def test_special_hand_yakuman_payments(players, preset, winner, kind, first_turn
     deltas[winner] = -sum(deltas)
     assert env.score_deltas == deltas
     assert env.scores() == [100000 + delta for delta in deltas]
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("double_kokushi", [True, False], ids=["double", "single"])
+def test_tenhou_kokushi_score_is_independent_of_initial_deal_order(players, double_kokushi):
+    # Observed Mahjong Soul behavior: https://mj-news.net/column/nemata-quiz/20200516145895
+    # Every choice of the 14th dealt tile must yield the same highest-scoring hand.
+    rule = GameRule.default_mjsoul()
+    rule.is_kokushi_musou_13machi_double = double_kokushi
+    for tile in HANDS["kokushi"][0] + [HANDS["kokushi"][1]]:
+        wall, _, _ = setup_wall(players, 0, "kokushi", True, winning_tile=tile)
+        env = RiichiEnv(f"{players}p-red-single", rule=rule, seed=42)
+        env.reset(wall=wall, oya=0, scores=[100000] * players)
+        assert env.drawn_tile == tile
+        tsumo = next(a for a in env.get_observation(0).legal_actions() if a.action_type == ActionType.TSUMO)
+        env.step({0: tsumo})
+        assert env.is_done
+        result = env.win_results[0]
+        units = 3 if double_kokushi else 2
+        assert result.han == 13 * units
+        assert sorted(result.yaku) == [35, 49]
+        assert result.tsumo_agari_ko == 16000 * units
+        assert env.score_deltas == [16000 * units * (players - 1)] + [-16000 * units] * (players - 1)

--- a/tests/env/agari/test_special_hand_yakuman.py
+++ b/tests/env/agari/test_special_hand_yakuman.py
@@ -1,0 +1,102 @@
+"""Exercise special-hand scoring from complete walls using legal actions."""
+
+import pytest
+
+from riichienv import ActionType, GameRule, Phase, RiichiEnv
+
+HANDS = {
+    # Single-wait kokushi: pair of 1m, missing White.
+    "kokushi": ([0, 1, 32, 36, 68, 72, 104, 108, 112, 116, 120, 128, 132], 124),
+    "kokushi_13": ([0, 32, 36, 68, 72, 104, 108, 112, 116, 120, 124, 128, 132], 1),
+    "seven_pairs": ([32, 33, 36, 37, 48, 49, 64, 65, 84, 92, 93, 96, 97], 85),
+    "all_honors": ([108, 109, 112, 113, 116, 117, 120, 121, 124, 125, 128, 129, 132], 133),
+}
+
+
+def setup_wall(players, winner, kind, first_turn):
+    hand, winning_tile = HANDS[kind]
+    all_tiles = [t for t in range(136) if players == 4 or t < 4 or t >= 32]
+    # 6p indicates 7p, absent from every test hand. Keep it in the dead wall.
+    indicator = 56
+    pool = [t for t in all_tiles if t not in hand and t not in (winning_tile, indicator)]
+    hands = []
+    for seat in range(players):
+        if seat == winner:
+            hands.append(hand)
+        else:
+            hands.append(pool[:13])
+            del pool[:13]
+    before_win = winner + (0 if first_turn else players)
+    draws = [pool.pop() for _ in range(before_win)] + [winning_tile]
+    wall = [t for start in (0, 4, 8) for h in hands for t in h[start : start + 4]]
+    wall += [h[12] for h in hands] + draws + pool + [indicator]
+    index = 99 if players == 3 else len(wall) - 5
+    wall[index], wall[-1] = wall[-1], wall[index]
+    assert sorted(wall) == all_tiles
+    return wall, before_win, all_tiles
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("preset", ["tenhou", "mjsoul"])
+@pytest.mark.parametrize("winner", [0, 1], ids=["dealer", "nondealer"])
+@pytest.mark.parametrize("kind", HANDS)
+@pytest.mark.parametrize("first_turn", [True, False], ids=["first_draw", "later_draw"])
+def test_special_hand_yakuman_payments(players, preset, winner, kind, first_turn):
+    wall, before_win, all_tiles = setup_wall(players, winner, kind, first_turn)
+    rule = getattr(GameRule, f"default_{preset}")()
+    env = RiichiEnv(f"{players}p-red-single", rule=rule, seed=42)
+    env.reset(wall=wall, oya=0, scores=[100000] * players)
+
+    def step(actions):
+        env.step(actions)
+        assert not any(str(e.get("reason", "")).startswith("Error:") for e in env.mjai_log)
+        tiles = env.wall + [t for h in env.hands for t in h] + [t for d in env.discards for t in d]
+        assert sorted(tiles) == all_tiles
+        assert sum(env.scores()) + 1000 * env.riichi_sticks == 100000 * players
+
+    for _ in range(before_win):
+        seat = env.current_player
+        discard = next(
+            a
+            for a in env.get_observation(seat).legal_actions()
+            if a.action_type == ActionType.DISCARD and a.tile == env.drawn_tile
+        )
+        step({seat: discard})
+        if env.phase == Phase.WaitResponse:
+            step(
+                {
+                    p: next(a for a in env.get_observation(p).legal_actions() if a.action_type == ActionType.PASS)
+                    for p in env.active_players
+                }
+            )
+    assert env.current_player == winner
+    assert env.drawn_tile == HANDS[kind][1]
+    assert env.dora_indicators == [56]
+    tsumo = next(a for a in env.get_observation(winner).legal_actions() if a.action_type == ActionType.TSUMO)
+    step({winner: tsumo})
+    assert env.is_done
+
+    units = int(first_turn)
+    expected_yaku = [35 if winner == 0 else 36] if first_turn else []
+    if kind in ("kokushi", "kokushi_13"):
+        units += 1 + int(kind == "kokushi_13" and preset == "mjsoul")
+        expected_yaku.append(42 if kind == "kokushi" else 49)
+    elif kind == "all_honors":
+        units += 1
+        expected_yaku.append(39)
+    elif not first_turn:
+        expected_yaku = [1, 25]  # Menzen tsumo + seven pairs, 3 han / 25 fu.
+
+    result = env.win_results[winner]
+    assert result.yakuman == bool(units)
+    assert result.han == (13 * units if units else 3)
+    assert result.fu == (0 if units else 25)
+    assert sorted(result.yaku) == sorted(expected_yaku)
+    base_payment = 8000 * units if units else 800
+    deltas = [0] * players
+    for seat in range(players):
+        if seat != winner:
+            deltas[seat] = -base_payment * (2 if winner == 0 or seat == 0 else 1)
+    deltas[winner] = -sum(deltas)
+    assert env.score_deltas == deltas
+    assert env.scores() == [100000 + delta for delta in deltas]


### PR DESCRIPTION
Fix Kokushi Musou stacking with Tenhou/Chiihou and exclude ordinary yaku and bonus han from seven-pairs yakuman. This corrects missing and inflated yakuman payments in 3P/4P.