### PR TITLE
fix: correct discard observations and dora features

### DIFF
--- a/riichienv-core/src/observation/encode.rs
+++ b/riichienv-core/src/observation/encode.rs
@@ -491,16 +491,16 @@ impl Observation {
                 },
             );
 
-            let dora_tiles: Vec<u8> = self
+            let dora_types: Vec<u8> = self
                 .dora_indicators
                 .iter()
-                .map(|&ind| get_next_tile(ind))
+                .map(|&ind| get_next_tile(ind) / 4)
                 .collect();
             broadcast_scalar(
                 buf,
                 ch_offset,
                 2,
-                if dora_tiles.contains(&(tile as u8)) {
+                if dora_types.contains(&((tile / 4) as u8)) {
                     1.0
                 } else {
                     0.0
@@ -511,10 +511,10 @@ impl Observation {
 
     /// Write 9 last tedashis channels (broadcast) into buf starting at ch_offset.
     pub(crate) fn encode_last_ted_into(&self, buf: &mut [f32], ch_offset: usize) {
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&ind| get_next_tile(ind))
+            .map(|&ind| get_next_tile(ind) / 4)
             .collect();
 
         let mut opp_idx = 0;
@@ -539,7 +539,11 @@ impl Observation {
                     buf,
                     ch_offset,
                     opp_idx * 3 + 2,
-                    if dora_tiles.contains(&tile) { 1.0 } else { 0.0 },
+                    if dora_types.contains(&(tile / 4)) {
+                        1.0
+                    } else {
+                        0.0
+                    },
                 );
             }
             opp_idx += 1;
@@ -548,10 +552,10 @@ impl Observation {
 
     /// Write 9 riichi sutehais channels (broadcast) into buf starting at ch_offset.
     pub(crate) fn encode_riichi_sute_into(&self, buf: &mut [f32], ch_offset: usize) {
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&ind| get_next_tile(ind))
+            .map(|&ind| get_next_tile(ind) / 4)
             .collect();
 
         let mut opp_idx = 0;
@@ -576,7 +580,11 @@ impl Observation {
                     buf,
                     ch_offset,
                     opp_idx * 3 + 2,
-                    if dora_tiles.contains(&tile) { 1.0 } else { 0.0 },
+                    if dora_types.contains(&(tile / 4)) {
+                        1.0
+                    } else {
+                        0.0
+                    },
                 );
             }
             opp_idx += 1;
@@ -800,5 +808,65 @@ mod tests {
                 self_tile_type
             );
         }
+    }
+
+    #[test]
+    fn test_discard_feature_dora_copies() {
+        // Indicator -> dora physical IDs, including suit/honor wraparound.
+        let pairs = [
+            (12, 16),
+            (32, 0),
+            (48, 52),
+            (68, 36),
+            (84, 88),
+            (104, 72),
+            (120, 108),
+            (132, 124),
+        ];
+        for (indicator, dora) in pairs {
+            for copy in 0..4 {
+                for (tile, is_dora) in [(dora + copy, 1.0), (indicator + copy, 0.0)] {
+                    let mut obs = make_obs(1, Default::default(), empty_melds());
+                    obs.dora_indicators = vec![indicator as u32 + copy as u32];
+                    obs.last_discard = Some(tile as u32);
+                    obs.last_tedashis[0] = Some(tile);
+                    obs.riichi_sutehais[0] = Some(tile);
+                    let aka = if matches!(tile, 16 | 52 | 88) {
+                        1.0
+                    } else {
+                        0.0
+                    };
+                    // Use the public extended layout offsets; unfilled opponents stay zero.
+                    let mut buf = vec![0.0; 215 * 34];
+                    obs.encode_pass_ctx_into(&mut buf, 194);
+                    obs.encode_last_ted_into(&mut buf, 197);
+                    obs.encode_riichi_sute_into(&mut buf, 206);
+                    for start in [194, 197, 206] {
+                        for column in 0..34 {
+                            assert_eq!(buf[(start + 1) * 34 + column], aka);
+                            assert_eq!(
+                                buf[(start + 2) * 34 + column],
+                                is_dora,
+                                "indicator={indicator}, tile={tile}, channel={start}"
+                            );
+                        }
+                    }
+                    for start in [200, 209] {
+                        assert!(buf[start * 34..(start + 6) * 34].iter().all(|&v| v == 0.0));
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_missing_discard_features_stay_zero() {
+        let mut obs = make_obs(1, Default::default(), empty_melds());
+        obs.dora_indicators = vec![48];
+        let mut buf = vec![0.0; 215 * 34];
+        obs.encode_pass_ctx_into(&mut buf, 194);
+        obs.encode_last_ted_into(&mut buf, 197);
+        obs.encode_riichi_sute_into(&mut buf, 206);
+        assert!(buf.iter().all(|&v| v == 0.0));
     }
 }

--- a/riichienv-core/src/observation/python.rs
+++ b/riichienv-core/src/observation/python.rs
@@ -1070,10 +1070,10 @@ impl Observation {
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
         let mut arr = Array2::<f32>::zeros((3, 3));
 
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&indicator| get_next_tile(indicator))
+            .map(|&indicator| get_next_tile(indicator) / 4)
             .collect();
 
         let mut opponent_idx = 0;
@@ -1093,7 +1093,7 @@ impl Observation {
                 arr[[opponent_idx, 1]] = if is_aka { 1.0 } else { 0.0 };
 
                 // Channel 2: is dora
-                let is_dora = dora_tiles.contains(&tile);
+                let is_dora = dora_types.contains(&(tile / 4));
                 arr[[opponent_idx, 2]] = if is_dora { 1.0 } else { 0.0 };
             }
 
@@ -1120,10 +1120,10 @@ impl Observation {
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
         let mut arr = Array2::<f32>::zeros((3, 3));
 
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&indicator| get_next_tile(indicator))
+            .map(|&indicator| get_next_tile(indicator) / 4)
             .collect();
 
         let mut opponent_idx = 0;
@@ -1143,7 +1143,7 @@ impl Observation {
                 arr[[opponent_idx, 1]] = if is_aka { 1.0 } else { 0.0 };
 
                 // Channel 2: is dora
-                let is_dora = dora_tiles.contains(&tile);
+                let is_dora = dora_types.contains(&(tile / 4));
                 arr[[opponent_idx, 2]] = if is_dora { 1.0 } else { 0.0 };
             }
 
@@ -1179,12 +1179,12 @@ impl Observation {
             arr[1] = if is_aka { 1.0 } else { 0.0 };
 
             // Channel 2: is dora
-            let dora_tiles: Vec<u8> = self
+            let dora_types: Vec<u8> = self
                 .dora_indicators
                 .iter()
-                .map(|&indicator| get_next_tile(indicator))
+                .map(|&indicator| get_next_tile(indicator) / 4)
                 .collect();
-            let is_dora = dora_tiles.contains(&(tile as u8));
+            let is_dora = dora_types.contains(&((tile / 4) as u8));
             arr[2] = if is_dora { 1.0 } else { 0.0 };
         }
 

--- a/riichienv-core/src/observation_3p/encode.rs
+++ b/riichienv-core/src/observation_3p/encode.rs
@@ -515,16 +515,16 @@ impl Observation3P {
                 },
             );
 
-            let dora_tiles: Vec<u8> = self
+            let dora_types: Vec<u8> = self
                 .dora_indicators
                 .iter()
-                .map(|&ind| self.dora_next(ind))
+                .map(|&ind| self.dora_next(ind) / 4)
                 .collect();
             broadcast_scalar(
                 buf,
                 ch_offset,
                 2,
-                if dora_tiles.contains(&(tile as u8)) {
+                if dora_types.contains(&((tile / 4) as u8)) {
                     1.0
                 } else {
                     0.0
@@ -536,10 +536,10 @@ impl Observation3P {
     /// Write 6 last tedashis channels (broadcast) into buf starting at ch_offset.
     /// 2 opponents x 3 features = 6 channels.
     pub(crate) fn encode_last_ted_into(&self, buf: &mut [f32], ch_offset: usize) {
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&ind| self.dora_next(ind))
+            .map(|&ind| self.dora_next(ind) / 4)
             .collect();
 
         let mut opp_idx = 0;
@@ -566,7 +566,11 @@ impl Observation3P {
                     buf,
                     ch_offset,
                     opp_idx * 3 + 2,
-                    if dora_tiles.contains(&tile) { 1.0 } else { 0.0 },
+                    if dora_types.contains(&(tile / 4)) {
+                        1.0
+                    } else {
+                        0.0
+                    },
                 );
             }
             opp_idx += 1;
@@ -576,10 +580,10 @@ impl Observation3P {
     /// Write 6 riichi sutehais channels (broadcast) into buf starting at ch_offset.
     /// 2 opponents x 3 features = 6 channels.
     pub(crate) fn encode_riichi_sute_into(&self, buf: &mut [f32], ch_offset: usize) {
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&ind| self.dora_next(ind))
+            .map(|&ind| self.dora_next(ind) / 4)
             .collect();
 
         let mut opp_idx = 0;
@@ -606,7 +610,11 @@ impl Observation3P {
                     buf,
                     ch_offset,
                     opp_idx * 3 + 2,
-                    if dora_tiles.contains(&tile) { 1.0 } else { 0.0 },
+                    if dora_types.contains(&(tile / 4)) {
+                        1.0
+                    } else {
+                        0.0
+                    },
                 );
             }
             opp_idx += 1;
@@ -788,5 +796,69 @@ mod tests {
                 pid
             );
         }
+    }
+
+    #[test]
+    fn test_discard_feature_dora_copies() {
+        // Indicator -> dora physical IDs, including suit/honor wraparound.
+        let pairs = [
+            (0, 32),
+            (32, 0),
+            (48, 52),
+            (68, 36),
+            (84, 88),
+            (104, 72),
+            (120, 108),
+            (132, 124),
+        ];
+        for (indicator, dora) in pairs {
+            for copy in 0..4 {
+                for (tile, is_dora) in [(dora + copy, 1.0), (indicator + copy, 0.0)] {
+                    let mut obs = make_obs(1, Default::default(), empty_melds());
+                    obs.dora_indicators = vec![indicator as u32 + copy as u32];
+                    obs.last_discard = Some(tile as u32);
+                    obs.last_tedashis[0] = Some(tile);
+                    obs.riichi_sutehais[0] = Some(tile);
+                    let aka = if matches!(tile, 16 | 52 | 88) {
+                        1.0
+                    } else {
+                        0.0
+                    };
+                    // Use the public extended layout offsets; unfilled opponents stay zero.
+                    let mut buf = vec![0.0; 215 * TILE_DIM_3P];
+                    obs.encode_pass_ctx_into(&mut buf, 194);
+                    obs.encode_last_ted_into(&mut buf, 197);
+                    obs.encode_riichi_sute_into(&mut buf, 206);
+                    for start in [194, 197, 206] {
+                        for column in 0..TILE_DIM_3P {
+                            assert_eq!(buf[(start + 1) * TILE_DIM_3P + column], aka);
+                            assert_eq!(
+                                buf[(start + 2) * TILE_DIM_3P + column],
+                                is_dora,
+                                "indicator={indicator}, tile={tile}, channel={start}"
+                            );
+                        }
+                    }
+                    for start in [200, 209] {
+                        assert!(
+                            buf[start * TILE_DIM_3P..(start + 6) * TILE_DIM_3P]
+                                .iter()
+                                .all(|&v| v == 0.0)
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_missing_discard_features_stay_zero() {
+        let mut obs = make_obs(1, Default::default(), empty_melds());
+        obs.dora_indicators = vec![48];
+        let mut buf = vec![0.0; 215 * TILE_DIM_3P];
+        obs.encode_pass_ctx_into(&mut buf, 194);
+        obs.encode_last_ted_into(&mut buf, 197);
+        obs.encode_riichi_sute_into(&mut buf, 206);
+        assert!(buf.iter().all(|&v| v == 0.0));
     }
 }

--- a/riichienv-core/src/observation_3p/python.rs
+++ b/riichienv-core/src/observation_3p/python.rs
@@ -940,10 +940,10 @@ impl Observation3P {
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
         let mut arr = Array2::<f32>::zeros((NP - 1, 3));
 
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&indicator| get_next_tile_sanma(indicator))
+            .map(|&indicator| get_next_tile_sanma(indicator) / 4)
             .collect();
 
         let mut opponent_idx = 0;
@@ -959,7 +959,7 @@ impl Observation3P {
                 }
                 let is_aka = matches!(tile, 16 | 52 | 88);
                 arr[[opponent_idx, 1]] = if is_aka { 1.0 } else { 0.0 };
-                let is_dora = dora_tiles.contains(&tile);
+                let is_dora = dora_types.contains(&(tile / 4));
                 arr[[opponent_idx, 2]] = if is_dora { 1.0 } else { 0.0 };
             }
 
@@ -984,10 +984,10 @@ impl Observation3P {
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
         let mut arr = Array2::<f32>::zeros((NP - 1, 3));
 
-        let dora_tiles: Vec<u8> = self
+        let dora_types: Vec<u8> = self
             .dora_indicators
             .iter()
-            .map(|&indicator| get_next_tile_sanma(indicator))
+            .map(|&indicator| get_next_tile_sanma(indicator) / 4)
             .collect();
 
         let mut opponent_idx = 0;
@@ -1003,7 +1003,7 @@ impl Observation3P {
                 }
                 let is_aka = matches!(tile, 16 | 52 | 88);
                 arr[[opponent_idx, 1]] = if is_aka { 1.0 } else { 0.0 };
-                let is_dora = dora_tiles.contains(&tile);
+                let is_dora = dora_types.contains(&(tile / 4));
                 arr[[opponent_idx, 2]] = if is_dora { 1.0 } else { 0.0 };
             }
 
@@ -1035,12 +1035,12 @@ impl Observation3P {
             }
             let is_aka = matches!(tile, 16 | 52 | 88);
             arr[1] = if is_aka { 1.0 } else { 0.0 };
-            let dora_tiles: Vec<u8> = self
+            let dora_types: Vec<u8> = self
                 .dora_indicators
                 .iter()
-                .map(|&indicator| get_next_tile_sanma(indicator))
+                .map(|&indicator| get_next_tile_sanma(indicator) / 4)
                 .collect();
-            let is_dora = dora_tiles.contains(&(tile as u8));
+            let is_dora = dora_types.contains(&((tile / 4) as u8));
             arr[2] = if is_dora { 1.0 } else { 0.0 };
         }
 

--- a/riichienv-core/src/state/event_handler.rs
+++ b/riichienv-core/src/state/event_handler.rs
@@ -121,7 +121,11 @@ impl GameStateEventHandler for GameState {
                 self.active_players = vec![actor as u8];
                 self.needs_tsumo = false;
             }
-            MjaiEvent::Dahai { actor, pai, .. } => {
+            MjaiEvent::Dahai {
+                actor,
+                pai,
+                tsumogiri,
+            } => {
                 let tile = parse_mjai_tile(&pai);
                 self.current_player = actor as u8;
                 if let Some(idx) = self.players[actor].hand.iter().position(|&t| t == tile) {
@@ -129,6 +133,9 @@ impl GameStateEventHandler for GameState {
                 }
                 self.players[actor].discards.push(tile);
                 self.last_discard = Some((actor as u8, tile));
+                if !tsumogiri {
+                    self.last_tedashis[actor] = Some(tile);
+                }
                 self.drawn_tile = None;
                 self.turn_count += 1;
                 if self.turn_count >= self.players.len() as u32 {
@@ -136,6 +143,7 @@ impl GameStateEventHandler for GameState {
                 }
 
                 if self.players[actor].riichi_stage {
+                    self.riichi_sutehais[actor] = Some(tile);
                     self.players[actor].riichi_declared = true;
                     self.players[actor].riichi_stage = false;
                 }
@@ -401,6 +409,12 @@ impl GameStateEventHandler for GameState {
                     .discard_is_riichi
                     .push(*is_liqi || *is_wliqi);
                 self.last_discard = Some((s as u8, t));
+                if !is_tsumogiri {
+                    self.last_tedashis[s] = Some(t);
+                }
+                if *is_liqi || *is_wliqi {
+                    self.riichi_sutehais[s] = Some(t);
+                }
                 self.drawn_tile = None;
                 // Reset same-turn furiten after own discard.
                 self.players[s].missed_agari_doujun = false;

--- a/riichienv-core/src/state/mod.rs
+++ b/riichienv-core/src/state/mod.rs
@@ -249,7 +249,7 @@ impl GameState {
             is_tenpai,
             self.riichi_sutehais,
             self.last_tedashis,
-            self.last_discard.map(|(tile, _pid)| tile as u32),
+            self.last_discard.map(|(_pid, tile)| tile as u32),
             self.drawn_tile,
         );
 
@@ -462,12 +462,6 @@ impl GameState {
                                     && dt == t
                                 {
                                     tsumogiri = true;
-                                }
-                                // Record riichi sutehai (riichi discard tile)
-                                self.riichi_sutehais[pid as usize] = Some(t);
-                                // Record last tedashi if not tsumogiri
-                                if !tsumogiri {
-                                    self.last_tedashis[pid as usize] = Some(t);
                                 }
                                 if let Some(idx) =
                                     self.players[pid as usize].hand.iter().position(|&x| x == t)
@@ -1350,6 +1344,7 @@ impl GameState {
         self.needs_tsumo = true;
 
         if self.players[pid as usize].riichi_stage {
+            self.riichi_sutehais[pid as usize] = Some(tile);
             self.players[pid as usize].riichi_declared = true;
             if self.is_first_turn {
                 self.players[pid as usize].double_riichi_declared = true;

--- a/riichienv-core/src/state_3p/event_handler.rs
+++ b/riichienv-core/src/state_3p/event_handler.rs
@@ -123,7 +123,11 @@ impl GameState3PEventHandler for GameState3P {
                 self.active_players = vec![actor as u8];
                 self.needs_tsumo = false;
             }
-            MjaiEvent::Dahai { actor, pai, .. } => {
+            MjaiEvent::Dahai {
+                actor,
+                pai,
+                tsumogiri,
+            } => {
                 let tile = parse_mjai_tile(&pai);
                 self.current_player = actor as u8;
                 if let Some(idx) = self.players[actor].hand.iter().position(|&t| t == tile) {
@@ -131,6 +135,9 @@ impl GameState3PEventHandler for GameState3P {
                 }
                 self.players[actor].discards.push(tile);
                 self.last_discard = Some((actor as u8, tile));
+                if !tsumogiri {
+                    self.last_tedashis[actor] = Some(tile);
+                }
                 self.drawn_tile = None;
                 self.turn_count += 1;
                 if self.turn_count >= self.players.len() as u32 {
@@ -138,6 +145,7 @@ impl GameState3PEventHandler for GameState3P {
                 }
 
                 if self.players[actor].riichi_stage {
+                    self.riichi_sutehais[actor] = Some(tile);
                     self.players[actor].riichi_declared = true;
                     self.players[actor].riichi_stage = false;
                 }
@@ -405,6 +413,12 @@ impl GameState3PEventHandler for GameState3P {
                     .discard_is_riichi
                     .push(*is_liqi || *is_wliqi);
                 self.last_discard = Some((s as u8, t));
+                if !is_tsumogiri {
+                    self.last_tedashis[s] = Some(t);
+                }
+                if *is_liqi || *is_wliqi {
+                    self.riichi_sutehais[s] = Some(t);
+                }
                 self.drawn_tile = None;
                 // Reset same-turn furiten after own discard.
                 self.players[s].missed_agari_doujun = false;

--- a/riichienv-core/src/state_3p/mod.rs
+++ b/riichienv-core/src/state_3p/mod.rs
@@ -217,7 +217,7 @@ impl GameState3P {
             is_tenpai,
             self.riichi_sutehais,
             self.last_tedashis,
-            self.last_discard.map(|(tile, _pid)| tile as u32),
+            self.last_discard.map(|(_pid, tile)| tile as u32),
             self.drawn_tile,
         )
     }
@@ -423,10 +423,6 @@ impl GameState3P {
                                     && dt == t
                                 {
                                     tsumogiri = true;
-                                }
-                                self.riichi_sutehais[pid as usize] = Some(t);
-                                if !tsumogiri {
-                                    self.last_tedashis[pid as usize] = Some(t);
                                 }
                                 if let Some(idx) =
                                     self.players[pid as usize].hand.iter().position(|&x| x == t)
@@ -1260,6 +1256,7 @@ impl GameState3P {
         self.needs_tsumo = true;
 
         if self.players[pid as usize].riichi_stage {
+            self.riichi_sutehais[pid as usize] = Some(tile);
             self.players[pid as usize].riichi_declared = true;
             if self.is_first_turn {
                 self.players[pid as usize].double_riichi_declared = true;

--- a/riichienv-core/tests/observation_discard_history.rs
+++ b/riichienv-core/tests/observation_discard_history.rs
@@ -1,0 +1,97 @@
+use riichienv_core::replay::{Action as LogAction, MjaiEvent};
+use riichienv_core::rule::GameRule;
+
+macro_rules! discard_history_tests {
+    ($name:ident, $state:path, $mode:expr, $np:expr) => {
+        mod $name {
+            use super::*;
+            type State = $state;
+
+            fn setup() -> State {
+                let mut state = State::new($mode, false, Some(42), 0, GameRule::default_mjsoul());
+                for player in &mut state.players {
+                    player.reset_round();
+                }
+                state.players[1].hand = vec![48, 53, 56];
+                state
+            }
+
+            fn check(state: &mut State, last: u8, tedashi: u8, riichi: Option<u8>) {
+                for observer in 0..$np {
+                    let obs = state.get_observation(observer);
+                    assert_eq!(obs.last_discard, Some(last as u32));
+                    assert_eq!(obs.last_tedashis[1], Some(tedashi));
+                    assert_eq!(obs.riichi_sutehais[1], riichi);
+                }
+            }
+
+            #[test]
+            fn mjai_discard_history_tracks_riichi_and_tedashi() {
+                for tsumogiri in [false, true] {
+                    let mut state = setup();
+                    state.apply_mjai_event(MjaiEvent::Dahai {
+                        actor: 1,
+                        pai: "4p".into(),
+                        tsumogiri: false,
+                    });
+                    check(&mut state, 48, 48, None);
+                    state.apply_mjai_event(MjaiEvent::Reach { actor: 1 });
+                    state.apply_mjai_event(MjaiEvent::Dahai {
+                        actor: 1,
+                        pai: "5p".into(),
+                        tsumogiri,
+                    });
+                    let tedashi = if tsumogiri { 48 } else { 53 };
+                    check(&mut state, 53, tedashi, Some(53));
+                    state.apply_mjai_event(MjaiEvent::Dahai {
+                        actor: 1,
+                        pai: "6p".into(),
+                        tsumogiri: true,
+                    });
+                    check(&mut state, 56, tedashi, Some(53));
+                }
+            }
+
+            #[test]
+            fn log_discard_history_tracks_riichi_and_tedashi() {
+                for (is_liqi, is_wliqi) in [(false, false), (true, false), (false, true)] {
+                    for tsumogiri in [false, true] {
+                        let mut state = setup();
+                        state.drawn_tile = Some(56);
+                        state.apply_log_action(&LogAction::DiscardTile {
+                            seat: 1,
+                            tile: 48,
+                            is_liqi: false,
+                            is_wliqi: false,
+                            doras: None,
+                        });
+                        check(&mut state, 48, 48, None);
+                        state.drawn_tile = Some(if tsumogiri { 53 } else { 56 });
+                        state.apply_log_action(&LogAction::DiscardTile {
+                            seat: 1,
+                            tile: 53,
+                            is_liqi,
+                            is_wliqi,
+                            doras: None,
+                        });
+                        let tedashi = if tsumogiri { 48 } else { 53 };
+                        let riichi = if is_liqi || is_wliqi { Some(53) } else { None };
+                        check(&mut state, 53, tedashi, riichi);
+                        state.drawn_tile = Some(56);
+                        state.apply_log_action(&LogAction::DiscardTile {
+                            seat: 1,
+                            tile: 56,
+                            is_liqi: false,
+                            is_wliqi: false,
+                            doras: None,
+                        });
+                        check(&mut state, 56, tedashi, riichi);
+                    }
+                }
+            }
+        }
+    };
+}
+
+discard_history_tests!(four_player, riichienv_core::state::GameState, 0, 4);
+discard_history_tests!(three_player, riichienv_core::state_3p::GameState3P, 3, 3);

--- a/tests/test_observation_tile_features.py
+++ b/tests/test_observation_tile_features.py
@@ -1,0 +1,179 @@
+"""Physical tile IDs and dora features must agree across observation encoders."""
+
+import pytest
+
+from riichienv import Action, ActionType, GameRule, Observation, Observation3P, Phase, RiichiEnv
+
+
+def tile_types(players):
+    return [0, *range(8, 34)] if players == 3 else list(range(34))
+
+
+def dora_pairs(players):
+    # Explicit cycles keep the expected result independent of the engine helper.
+    manzu = [0, 8] if players == 3 else list(range(9))
+    cycles = [manzu, list(range(9, 18)), list(range(18, 27)), [27, 28, 29, 30], [31, 32, 33]]
+    return [(cycle[i - 1], kind) for cycle in cycles for i, kind in enumerate(cycle)]
+
+
+def make_observation(players, player_id, indicators, tile, target):
+    discards = [None] * players
+    discards[target] = tile
+    # Self must be excluded from the opponent features even if it has a discard.
+    discards[player_id] = 88
+    cls = Observation3P if players == 3 else Observation
+    hands = [[] for _ in range(players)]
+    hands[player_id] = [0, 1, 32, 33, 36, 37, 40, 41, 72, 73, 80, 81, 84]
+    return cls(
+        player_id=player_id,
+        hands=hands,
+        melds=[[] for _ in range(players)],
+        discards=[[] for _ in range(players)],
+        dora_indicators=indicators,
+        scores=[35000 if players == 3 else 25000] * players,
+        riichi_declared=[False] * players,
+        legal_actions=[],
+        events=[],
+        honba=0,
+        riichi_sticks=0,
+        round_wind=0,
+        oya=0,
+        kyoku_index=0,
+        waits=[],
+        is_tenpai=False,
+        riichi_sutehais=discards,
+        last_tedashis=discards,
+        last_discard=tile,
+    )
+
+
+def assert_tile_features(obs, players, tile, target, is_dora):
+    types = tile_types(players)
+    expected = (
+        [types.index(tile // 4) / (len(types) - 1), float(tile in (16, 52, 88)), float(is_dora)]
+        if tile is not None
+        else [0.0] * 3
+    )
+    opponents = [p for p in range(players) if p != obs.player_id]
+    opponent_features = [value for p in opponents for value in (expected if p == target else [0.0] * 3)]
+    features = [
+        (obs.encode_pass_context(), 194, expected),
+        (obs.encode_last_tedashis(), 197, opponent_features),
+        (obs.encode_riichi_sutehais(), 206, opponent_features),
+    ]
+    extended = memoryview(obs.encode_extended()).cast("f")
+    width = len(types)
+    assert len(extended) == 215 * width
+    for raw, offset, values in features:
+        assert list(memoryview(raw).cast("f")) == pytest.approx(values)
+        for channel, value in enumerate(values, offset):
+            assert list(extended[channel * width : (channel + 1) * width]) == pytest.approx([value] * width)
+    if players == 3:
+        # The third opponent's slots stay reserved in the 215-channel layout.
+        for start in (203, 212):
+            assert list(extended[start * width : (start + 3) * width]) == [0.0] * (3 * width)
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("copy", range(4))
+@pytest.mark.parametrize("indicator_copy", range(4))
+def test_dora_features_cover_every_tile_kind_and_copy(players, copy, indicator_copy):
+    for indicator_kind, dora_kind in dora_pairs(players):
+        player_id = indicator_kind % players
+        target = (player_id + 1 + copy % (players - 1)) % players
+        indicator = indicator_kind * 4 + indicator_copy
+        tile = dora_kind * 4 + copy
+        obs = make_observation(players, player_id, [indicator], tile, target)
+        assert_tile_features(obs, players, tile, target, is_dora=True)
+
+        # An indicator is not itself a dora, including red fives and honors.
+        tile = indicator_kind * 4 + copy
+        obs = make_observation(players, player_id, [indicator], tile, target)
+        assert_tile_features(obs, players, tile, target, is_dora=False)
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("tile", [None, 52, 53, 91])
+@pytest.mark.parametrize("indicators", [[], [48, 49, 84]])
+def test_dora_features_with_missing_tiles_and_multiple_indicators(players, tile, indicators):
+    obs = make_observation(players, 1, indicators, tile, 0)
+    # is_dora is a boolean even when two indicators refer to the same kind.
+    assert_tile_features(obs, players, tile, 0, is_dora=bool(indicators) and tile is not None)
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+def test_last_discard_preserves_physical_tile_for_every_observer(players, preset):
+    env = RiichiEnv(f"{players}p-red-single", seed=42, rule=getattr(GameRule, f"default_{preset}")())
+    cls = Observation3P if players == 3 else Observation
+    for observer in range(players):
+        assert env.get_observation(observer).last_discard is None
+
+    actors = set()
+    for _ in range(players * 2):
+        actor = env.current_player
+        actors.add(actor)
+        discard = next(a for a in env._get_legal_actions(actor) if a.action_type == ActionType.DISCARD and a.tile > 3)
+        env.step({actor: discard})
+        assert env.last_discard == (actor, discard.tile)
+        for observer in range(players):
+            obs = env.get_observation(observer)
+            assert obs.last_discard == discard.tile
+            restored = cls.deserialize_from_base64(obs.serialize_to_base64())
+            assert restored.last_discard == discard.tile
+            expected_kind = tile_types(players).index(discard.tile // 4) / (len(tile_types(players)) - 1)
+            assert memoryview(obs.encode_pass_context()).cast("f")[0] == pytest.approx(expected_kind)
+        while env.phase == Phase.WaitResponse:
+            env.step({p: Action(ActionType.PASS) for p in env.active_players})
+    assert actors == set(range(players))
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+@pytest.mark.parametrize("tsumogiri", [False, True])
+def test_riichi_discard_features_after_separate_declaration(players, preset, tsumogiri):
+    # A complete wall deals 111333555777p EE to the dealer. Discarding 5p
+    # leaves a shanpon wait; 4p is the indicator, making the non-red 5p dora.
+    tile = 53
+    drawn = tile if tsumogiri else 109
+    hand = [36, 37, 38, 44, 45, 46, 52, 53, 54, 60, 61, 62, 108, 109]
+    pool = [t for kind in tile_types(players) for t in range(kind * 4, kind * 4 + 4) if t not in [*hand, 48]]
+    hands = [[t for t in hand if t != drawn]]
+    for _ in range(players - 1):
+        hands.append(pool[:13])
+        del pool[:13]
+    deal = [t for start in (0, 4, 8) for h in hands for t in h[start : start + 4]]
+    tail = 8 if players == 3 else 4
+    wall = deal + [h[12] for h in hands] + [drawn] + pool[:-tail] + [48] + pool[-tail:]
+    assert sorted(wall) == [t for kind in tile_types(players) for t in range(kind * 4, kind * 4 + 4)]
+    env = RiichiEnv(f"{players}p-red-single", seed=42, rule=getattr(GameRule, f"default_{preset}")())
+    env.reset(wall=wall, oya=0)
+    assert env.drawn_tile == drawn
+    assert env.dora_indicators == [48]
+
+    declare = next(a for a in env._get_legal_actions(0) if a.action_type == ActionType.RIICHI)
+    assert declare.tile is None
+    env.step({0: declare})
+    assert env.get_observation(1).riichi_sutehais == [None] * players
+    discard = next(a for a in env._get_legal_actions(0) if a.action_type == ActionType.DISCARD and a.tile == tile)
+    env.step({0: discard})
+    assert env.discard_is_riichi[0] == [True]
+
+    def check_discard():
+        for observer in range(players):
+            obs = env.get_observation(observer)
+            assert obs.riichi_sutehais == [tile] + [None] * (players - 1)
+            assert obs.last_tedashis[0] == (None if tsumogiri else tile)
+            if observer != 0:
+                expected = [tile_types(players).index(tile // 4) / (len(tile_types(players)) - 1), 0.0, 1.0]
+                assert list(memoryview(obs.encode_riichi_sutehais()).cast("f")[:3]) == pytest.approx(expected)
+                width = len(tile_types(players))
+                assert memoryview(obs.encode_extended()).cast("f")[208 * width] == 1.0
+
+    check_discard()
+    while env.phase == Phase.WaitResponse:
+        env.step({p: Action(ActionType.PASS) for p in env.active_players})
+    check_discard()
+    env.reset()
+    for observer in range(players):
+        assert env.get_observation(observer).riichi_sutehais == [None] * players


### PR DESCRIPTION
Fix incorrect discard features in both 3-player and 4-player observations.

- Return the physical last-discard tile and recognize every copy of a dora tile.
- Preserve riichi declaration tiles and last hand discards during simulation and replay.
- Add regression tests for tile copies, dora cycles, and discard history.