### PR TITLE
Fix Mahjong Soul dealer opening discard metadata

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -38,6 +38,12 @@ Controls whether players are forbidden from discarding a tile that completes the
 |------|-------------|
 | `.kuikae_forbidden` | When `True`, kuikae is forbidden: after Chi/Pon, the called tile and flank tiles cannot be discarded. When `False`, no kuikae restriction applies. |
 
+## Dealer's Initial Discard Metadata
+
+`dealer_first_discard_is_tedashi` records any discard from the dealer's uninterrupted initial 14 tiles as tedashi (`tsumogiri=false`). It is enabled by `GameRule.default_mjsoul()` to match Mahjong Soul logs in both 3P and 4P. The Tenhou preset and custom constructor keep the previous behavior by default (`false`).
+
+An initial kan or kita ends this convention; discarding its replacement tile can be tsumogiri. The initial drawn tile remains available for Tenhou (heavenly hand) scoring. Observations expose `forced_tedashi` so action encoders can follow the same convention without removing the drawn-tile information. Explicit tsumogiri flags in imported MJAI events are preserved.
+
 ## Kokushi Musou Rules
 
 | Flag | Description |

--- a/riichienv-core/src/observation/mod.rs
+++ b/riichienv-core/src/observation/mod.rs
@@ -53,6 +53,10 @@ pub struct Observation {
     pub last_discard: Option<u32>,
     #[serde(default)]
     pub drawn_tile: Option<u8>,
+    /// Every discard from this initial hand is recorded as tedashi, including
+    /// the drawn tile. Keep drawn_tile available for winning and hand features.
+    #[serde(default)]
+    pub forced_tedashi: bool,
 }
 
 /// Pure Rust methods (no PyO3 dependency).
@@ -107,6 +111,7 @@ impl Observation {
             last_tedashis,
             last_discard,
             drawn_tile,
+            forced_tedashi: false,
         }
     }
 

--- a/riichienv-core/src/observation/python.rs
+++ b/riichienv-core/src/observation/python.rs
@@ -14,7 +14,7 @@ use super::helpers::get_next_tile;
 impl Observation {
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard, drawn_tile=None))]
+    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard, drawn_tile=None, forced_tedashi=false))]
     pub fn py_new(
         player_id: u8,
         hands: Vec<Vec<u8>>,
@@ -36,6 +36,7 @@ impl Observation {
         last_tedashis: Vec<Option<u8>>,
         last_discard: Option<u32>,
         drawn_tile: Option<u8>,
+        forced_tedashi: bool,
     ) -> Self {
         let hands: [Vec<u8>; 4] = hands.try_into().expect("expected 4 hands");
         let melds: [Vec<Meld>; 4] = melds.try_into().expect("expected 4 melds");
@@ -49,7 +50,7 @@ impl Observation {
             .expect("expected 4 riichi_sutehais");
         let last_tedashis: [Option<u8>; 4] =
             last_tedashis.try_into().expect("expected 4 last_tedashis");
-        Self::new(
+        let mut obs = Self::new(
             player_id,
             hands,
             melds,
@@ -70,7 +71,9 @@ impl Observation {
             last_tedashis,
             last_discard,
             drawn_tile,
-        )
+        );
+        obs.forced_tedashi = forced_tedashi;
+        obs
     }
 
     #[getter]
@@ -124,7 +127,8 @@ impl Observation {
     pub fn select_action_from_mjai(&self, mjai_data: &Bound<'_, PyAny>) -> Option<Action> {
         use super::mjai_select::{parse_mjai_message, select_action};
         let parsed = parse_mjai_message(mjai_data)?;
-        select_action(&self._legal_actions, &parsed, self.drawn_tile, false).cloned()
+        let drawn_tile = self.drawn_tile.filter(|_| !self.forced_tedashi);
+        select_action(&self._legal_actions, &parsed, drawn_tile, false).cloned()
     }
 
     #[pyo3(name = "new_events")]

--- a/riichienv-core/src/observation/sequence_features.rs
+++ b/riichienv-core/src/observation/sequence_features.rs
@@ -814,6 +814,9 @@ impl Observation {
 
     /// Check if discarding this tile would be tsumogiri.
     fn is_tsumogiri_candidate(&self, tile: u8) -> bool {
+        if self.forced_tedashi {
+            return false;
+        }
         if let Some(drawn) = self.get_drawn_tile() {
             drawn == tile
         } else {

--- a/riichienv-core/src/observation_3p/mod.rs
+++ b/riichienv-core/src/observation_3p/mod.rs
@@ -43,6 +43,10 @@ pub struct Observation3P {
     pub last_discard: Option<u32>,
     #[serde(default)]
     pub drawn_tile: Option<u8>,
+    /// Every discard from this initial hand is recorded as tedashi, including
+    /// the drawn tile. Keep drawn_tile available for winning and hand features.
+    #[serde(default)]
+    pub forced_tedashi: bool,
 }
 
 /// Pure Rust methods (no PyO3 dependency).
@@ -99,6 +103,7 @@ impl Observation3P {
             last_tedashis,
             last_discard,
             drawn_tile,
+            forced_tedashi: false,
         }
     }
 

--- a/riichienv-core/src/observation_3p/python.rs
+++ b/riichienv-core/src/observation_3p/python.rs
@@ -17,7 +17,7 @@ const TOTAL_TILES: u32 = 108;
 impl Observation3P {
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard, drawn_tile=None))]
+    #[pyo3(signature = (player_id, hands, melds, discards, dora_indicators, scores, riichi_declared, legal_actions, events, honba, riichi_sticks, round_wind, oya, kyoku_index, waits, is_tenpai, riichi_sutehais, last_tedashis, last_discard, drawn_tile=None, forced_tedashi=false))]
     pub fn py_new(
         player_id: u8,
         hands: Vec<Vec<u8>>,
@@ -39,6 +39,7 @@ impl Observation3P {
         last_tedashis: Vec<Option<u8>>,
         last_discard: Option<u32>,
         drawn_tile: Option<u8>,
+        forced_tedashi: bool,
     ) -> Self {
         let hands: [Vec<u8>; 3] = hands.try_into().expect("expected 3 hands");
         let melds: [Vec<Meld>; 3] = melds.try_into().expect("expected 3 melds");
@@ -52,7 +53,7 @@ impl Observation3P {
             .expect("expected 3 riichi_sutehais");
         let last_tedashis: [Option<u8>; 3] =
             last_tedashis.try_into().expect("expected 3 last_tedashis");
-        Self::new(
+        let mut obs = Self::new(
             player_id,
             hands,
             melds,
@@ -73,7 +74,9 @@ impl Observation3P {
             last_tedashis,
             last_discard,
             drawn_tile,
-        )
+        );
+        obs.forced_tedashi = forced_tedashi;
+        obs
     }
 
     #[getter]
@@ -128,7 +131,8 @@ impl Observation3P {
         let parsed = parse_mjai_message(mjai_data)?;
         let inner_actions: Vec<Action> =
             self._legal_actions.iter().map(|a| (**a).clone()).collect();
-        let selected = select_action(&inner_actions, &parsed, self.drawn_tile, true)?;
+        let drawn_tile = self.drawn_tile.filter(|_| !self.forced_tedashi);
+        let selected = select_action(&inner_actions, &parsed, drawn_tile, true)?;
         // Re-find the corresponding Action3P instance to return.
         self._legal_actions
             .iter()

--- a/riichienv-core/src/rule.rs
+++ b/riichienv-core/src/rule.rs
@@ -17,6 +17,11 @@ pub struct GameRule {
     pub sanchaho_is_draw: bool,
 
     pub kuikae_forbidden: bool,
+
+    /// Treat the dealer's uninterrupted initial 14 tiles as hand tiles when
+    /// recording a discard. This does not change the first-draw win context.
+    #[serde(default)]
+    pub dealer_first_discard_is_tedashi: bool,
 }
 
 impl Default for GameRule {
@@ -38,6 +43,7 @@ impl GameRule {
             sanchaho_is_draw: true,
 
             kuikae_forbidden: true,
+            dealer_first_discard_is_tedashi: false,
         }
     }
 
@@ -53,6 +59,7 @@ impl GameRule {
             sanchaho_is_draw: false,
 
             kuikae_forbidden: true,
+            dealer_first_discard_is_tedashi: true,
         }
     }
 }
@@ -61,7 +68,7 @@ impl GameRule {
 #[pymethods]
 impl GameRule {
     #[new]
-    #[pyo3(signature = (allows_ron_on_ankan_for_kokushi_musou=false, is_kokushi_musou_13machi_double=false, is_suuankou_tanki_double=false, is_junsei_chuurenpoutou_double=false, is_daisuushii_double=false, yakuman_pao_is_liability_only=false, sanchaho_is_draw=false, kuikae_forbidden=true))]
+    #[pyo3(signature = (allows_ron_on_ankan_for_kokushi_musou=false, is_kokushi_musou_13machi_double=false, is_suuankou_tanki_double=false, is_junsei_chuurenpoutou_double=false, is_daisuushii_double=false, yakuman_pao_is_liability_only=false, sanchaho_is_draw=false, kuikae_forbidden=true, dealer_first_discard_is_tedashi=false))]
     #[allow(clippy::too_many_arguments)]
     pub fn py_new(
         allows_ron_on_ankan_for_kokushi_musou: bool,
@@ -72,6 +79,7 @@ impl GameRule {
         yakuman_pao_is_liability_only: bool,
         sanchaho_is_draw: bool,
         kuikae_forbidden: bool,
+        dealer_first_discard_is_tedashi: bool,
     ) -> Self {
         Self {
             allows_ron_on_ankan_for_kokushi_musou,
@@ -82,6 +90,7 @@ impl GameRule {
             yakuman_pao_is_liability_only,
             sanchaho_is_draw,
             kuikae_forbidden,
+            dealer_first_discard_is_tedashi,
         }
     }
 
@@ -99,7 +108,7 @@ impl GameRule {
 
     fn __repr__(&self) -> String {
         format!(
-            "GameRule(allows_ron_on_ankan_for_kokushi_musou={}, is_kokushi_musou_13machi_double={}, is_suuankou_tanki_double={}, is_junsei_chuurenpoutou_double={}, is_daisuushii_double={}, yakuman_pao_is_liability_only={}, sanchaho_is_draw={}, kuikae_forbidden={})",
+            "GameRule(allows_ron_on_ankan_for_kokushi_musou={}, is_kokushi_musou_13machi_double={}, is_suuankou_tanki_double={}, is_junsei_chuurenpoutou_double={}, is_daisuushii_double={}, yakuman_pao_is_liability_only={}, sanchaho_is_draw={}, kuikae_forbidden={}, dealer_first_discard_is_tedashi={})",
             self.allows_ron_on_ankan_for_kokushi_musou,
             self.is_kokushi_musou_13machi_double,
             self.is_suuankou_tanki_double,
@@ -107,7 +116,8 @@ impl GameRule {
             self.is_daisuushii_double,
             self.yakuman_pao_is_liability_only,
             self.sanchaho_is_draw,
-            self.kuikae_forbidden
+            self.kuikae_forbidden,
+            self.dealer_first_discard_is_tedashi
         )
     }
 }

--- a/riichienv-core/src/state/event_handler.rs
+++ b/riichienv-core/src/state/event_handler.rs
@@ -362,11 +362,7 @@ impl GameStateEventHandler for GameState {
             } => {
                 let s = *seat;
                 let t = *tile;
-                let is_tsumogiri = if let Some(dt) = self.drawn_tile {
-                    dt == t
-                } else {
-                    false
-                };
+                let is_tsumogiri = self.drawn_tile == Some(t) && !self.is_forced_tedashi(s as u8);
 
                 // Update progression cache (replay mode).
                 #[cfg(feature = "python")]

--- a/riichienv-core/src/state/mod.rs
+++ b/riichienv-core/src/state/mod.rs
@@ -229,7 +229,6 @@ impl GameState {
         let scores: [i32; 4] = std::array::from_fn(|i| self.players[i].score);
         let riichi_declared: [bool; 4] = std::array::from_fn(|i| self.players[i].riichi_declared);
 
-        #[cfg_attr(not(feature = "python"), allow(unused_mut))]
         let mut obs = Observation::new(
             player_id,
             masked_hands,
@@ -252,6 +251,8 @@ impl GameState {
             self.last_discard.map(|(_pid, tile)| tile as u32),
             self.drawn_tile,
         );
+
+        obs.forced_tedashi = self.is_forced_tedashi(player_id);
 
         // Attach pre-computed progression snapshot.
         #[cfg(feature = "python")]
@@ -1314,7 +1315,15 @@ impl GameState {
         }
     }
 
+    fn is_forced_tedashi(&self, pid: u8) -> bool {
+        self.rule.dealer_first_discard_is_tedashi
+            && pid == self.oya
+            && self.is_first_turn
+            && self.players[pid as usize].discards.is_empty()
+    }
+
     fn _resolve_discard(&mut self, pid: u8, tile: u8, tsumogiri: bool) {
+        let tsumogiri = tsumogiri && !self.is_forced_tedashi(pid);
         // After a discard the rinshan context is over. Clearing here ensures
         // that houtei (last-discard win) is correctly detected even when the
         // discard comes after a kan draw.

--- a/riichienv-core/src/state_3p/event_handler.rs
+++ b/riichienv-core/src/state_3p/event_handler.rs
@@ -397,11 +397,7 @@ impl GameState3PEventHandler for GameState3P {
             } => {
                 let s = *seat;
                 let t = *tile;
-                let is_tsumogiri = if let Some(dt) = self.drawn_tile {
-                    dt == t
-                } else {
-                    false
-                };
+                let is_tsumogiri = self.drawn_tile == Some(t) && !self.is_forced_tedashi(s as u8);
 
                 if let Some(idx) = self.players[s].hand.iter().position(|&x| x == t) {
                     self.players[s].hand.remove(idx);

--- a/riichienv-core/src/state_3p/mod.rs
+++ b/riichienv-core/src/state_3p/mod.rs
@@ -198,7 +198,7 @@ impl GameState3P {
         let scores: [i32; 3] = std::array::from_fn(|i| self.players[i].score);
         let riichi_declared: [bool; 3] = std::array::from_fn(|i| self.players[i].riichi_declared);
 
-        Observation3P::new(
+        let mut obs = Observation3P::new(
             player_id,
             masked_hands,
             melds,
@@ -219,7 +219,9 @@ impl GameState3P {
             self.last_tedashis,
             self.last_discard.map(|(_pid, tile)| tile as u32),
             self.drawn_tile,
-        )
+        );
+        obs.forced_tedashi = self.is_forced_tedashi(player_id);
+        obs
     }
 
     pub fn get_observation_for_replay(
@@ -1223,7 +1225,15 @@ impl GameState3P {
         }
     }
 
+    fn is_forced_tedashi(&self, pid: u8) -> bool {
+        self.rule.dealer_first_discard_is_tedashi
+            && pid == self.oya
+            && self.is_first_turn
+            && self.players[pid as usize].discards.is_empty()
+    }
+
     fn _resolve_discard(&mut self, pid: u8, tile: u8, tsumogiri: bool) {
+        let tsumogiri = tsumogiri && !self.is_forced_tedashi(pid);
         // A normal discard is never chankan, so clear any stale pending_kan
         // to prevent false chankan detection on subsequent ron claims.
         self.pending_kan = None;

--- a/riichienv-core/tests/observation_discard_history.rs
+++ b/riichienv-core/tests/observation_discard_history.rs
@@ -89,9 +89,88 @@ macro_rules! discard_history_tests {
                     }
                 }
             }
+
+            #[test]
+            fn log_dealer_initial_discard_obeys_configured_convention() {
+                for preset in [GameRule::default_tenhou(), GameRule::default_mjsoul()] {
+                    for dealer in 0..$np {
+                        for forced in [false, true] {
+                            for interrupted in [false, true] {
+                                let mut rule = preset;
+                                rule.dealer_first_discard_is_tedashi = forced;
+                                let mut state = State::new($mode, false, Some(42), 0, rule);
+                                state._initialize_round(dealer, 0, 0, 0, None, None);
+                                // Calls interrupt first-turn status even without a discard.
+                                state.is_first_turn = !interrupted;
+                                let tile = state.drawn_tile.unwrap();
+                                let tedashi = forced && !interrupted;
+                                assert_eq!(state.get_observation(dealer).forced_tedashi, tedashi);
+                                for observer in 0..$np {
+                                    if observer != dealer {
+                                        assert!(!state.get_observation(observer).forced_tedashi);
+                                    }
+                                }
+                                state.apply_log_action(&LogAction::DiscardTile {
+                                    seat: dealer as usize,
+                                    tile,
+                                    is_liqi: false,
+                                    is_wliqi: false,
+                                    doras: None,
+                                });
+                                assert_eq!(
+                                    state.players[dealer as usize].discard_from_hand,
+                                    vec![tedashi]
+                                );
+                                assert!(state.drawn_tile.is_none());
+                                for observer in 0..$np {
+                                    let obs = state.get_observation(observer);
+                                    assert_eq!(
+                                        obs.last_tedashis[dealer as usize],
+                                        tedashi.then_some(tile)
+                                    );
+                                    assert!(!obs.forced_tedashi);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            #[test]
+            fn explicit_mjai_initial_discard_metadata_is_preserved() {
+                for tsumogiri in [false, true] {
+                    let mut state = setup();
+                    state.apply_mjai_event(MjaiEvent::Tsumo {
+                        actor: 0,
+                        pai: "S".into(),
+                    });
+                    state.apply_mjai_event(MjaiEvent::Dahai {
+                        actor: 0,
+                        pai: "S".into(),
+                        tsumogiri,
+                    });
+                    assert_eq!(state.last_tedashis[0], (!tsumogiri).then_some(112));
+                }
+            }
         }
     };
 }
 
 discard_history_tests!(four_player, riichienv_core::state::GameState, 0, 4);
 discard_history_tests!(three_player, riichienv_core::state_3p::GameState3P, 3, 3);
+
+#[test]
+fn old_serialized_rules_keep_the_previous_discard_convention() {
+    for rule in [GameRule::default_tenhou(), GameRule::default_mjsoul()] {
+        let mut data = serde_json::to_value(rule).unwrap();
+        assert_eq!(
+            serde_json::from_value::<GameRule>(data.clone()).unwrap(),
+            rule
+        );
+        data.as_object_mut()
+            .unwrap()
+            .remove("dealer_first_discard_is_tedashi");
+        let restored: GameRule = serde_json::from_value(data).unwrap();
+        assert!(!restored.dealer_first_discard_is_tedashi);
+    }
+}

--- a/src/riichienv/_riichienv.pyi
+++ b/src/riichienv/_riichienv.pyi
@@ -15,6 +15,7 @@ class GameRule:
     yakuman_pao_is_liability_only: bool
     sanchaho_is_draw: bool
     kuikae_forbidden: bool
+    dealer_first_discard_is_tedashi: bool
     def __init__(
         self,
         allows_ron_on_ankan_for_kokushi_musou: bool = False,
@@ -25,6 +26,7 @@ class GameRule:
         yakuman_pao_is_liability_only: bool = False,
         sanchaho_is_draw: bool = False,
         kuikae_forbidden: bool = True,
+        dealer_first_discard_is_tedashi: bool = False,
     ) -> None: ...
     @staticmethod
     def default_tenhou() -> GameRule: ...
@@ -232,6 +234,7 @@ class Observation:
     hand: list[int]
     player_id: int
     prev_events_size: int
+    forced_tedashi: bool
     def new_events(self) -> list[str]:
         """Return MJAI JSON events unseen by this player since their previous observation.
 
@@ -502,6 +505,7 @@ class Observation3P:
     waits: list[int]
     is_tenpai: bool
     tsumogiri_flags: list[list[bool]]
+    forced_tedashi: bool
     riichi_sutehais: list[int | None]
     last_tedashis: list[int | None]
     last_discard: int | None

--- a/tests/env/test_dealer_first_discard.py
+++ b/tests/env/test_dealer_first_discard.py
@@ -1,0 +1,162 @@
+"""Mahjong Soul treats the dealer's uninterrupted initial hand as all tedashi."""
+
+import base64
+import json
+import random
+
+import pytest
+
+from riichienv import Action, ActionType, GameRule, Observation, Observation3P, Phase, RiichiEnv
+
+
+def setup_env(players, dealer, preset, drawn=53, opening=None, rule=None):
+    hand = [36, 37, 38, 44, 45, 46, 52, 53, 54, 60, 61, 62, 108, 109]
+    if opening == ActionType.ANKAN:
+        hand[12] = 39
+    elif opening == ActionType.KITA:
+        hand[12] = 120
+    tiles = [t for t in range(136) if players == 4 or t < 4 or t >= 32]
+    pool = [t for t in tiles if t not in hand and t != 48]
+    random.Random(42).shuffle(pool)
+    # The wall's dealing order starts at the dealer, regardless of seat number.
+    hands = [[t for t in hand if t != drawn]]
+    for _ in range(players - 1):
+        hands.append(pool[:13])
+        del pool[:13]
+    deal = [t for start in (0, 4, 8) for h in hands for t in h[start : start + 4]]
+    tail = 8 if players == 3 else 4
+    wall = deal + [h[12] for h in hands] + [drawn] + pool[:-tail] + [48] + pool[-tail:]
+    assert sorted(wall) == tiles
+    rule = rule if rule is not None else getattr(GameRule, f"default_{preset}")()
+    env = RiichiEnv(f"{players}p-red-single", seed=42, rule=rule)
+    observations = env.reset(wall=wall, oya=dealer)
+    assert env.drawn_tile == drawn
+    assert sorted(env.hands[dealer]) == sorted(hand)
+    return env, observations
+
+
+def discard(env, actor, tile):
+    action = next(a for a in env._get_legal_actions(actor) if a.action_type == ActionType.DISCARD and a.tile == tile)
+    env.step({actor: action})
+
+
+def pass_responses(env):
+    while env.phase == Phase.WaitResponse:
+        env.step({p: Action(ActionType.PASS) for p in env.active_players})
+
+
+def check_history(env, players, actor, tile, tedashi, last_tedashi):
+    assert env.discard_from_hand[actor][-1] is tedashi
+    event = next(e for e in reversed(env.mjai_log) if e["type"] == "dahai")
+    assert event["actor"] == actor
+    assert event["tsumogiri"] is not tedashi
+    cls = Observation3P if players == 3 else Observation
+    kinds = [0, *range(8, 34)] if players == 3 else list(range(34))
+    for observer in range(players):
+        obs = env.get_observation(observer)
+        restored = cls.deserialize_from_base64(obs.serialize_to_base64())
+        for view in (obs, restored):
+            assert view.last_discard == tile
+            assert view.last_tedashis[actor] == last_tedashi
+            if observer == actor:
+                continue
+            slot = [p for p in range(players) if p != observer].index(actor)
+            expected = (
+                [
+                    kinds.index(last_tedashi // 4) / (len(kinds) - 1),
+                    float(last_tedashi in (16, 52, 88)),
+                    float(last_tedashi // 4 == 13),
+                ]
+                if last_tedashi is not None
+                else [0.0] * 3
+            )
+            actual = list(memoryview(view.encode_last_tedashis()).cast("f"))[slot * 3 : (slot + 1) * 3]
+            assert actual == pytest.approx(expected)
+            extended = memoryview(view.encode_extended()).cast("f")
+            for channel, value in enumerate(expected, 197 + slot * 3):
+                assert list(extended[channel * len(kinds) : (channel + 1) * len(kinds)]) == pytest.approx(
+                    [value] * len(kinds)
+                )
+
+
+@pytest.mark.parametrize("players,dealer", [(p, d) for p in (3, 4) for d in range(p)])
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+@pytest.mark.parametrize("drawn", [52, 53, 109], ids=["red", "normal", "honor"])
+@pytest.mark.parametrize("discard_drawn", [False, True])
+def test_dealer_initial_discard_metadata(players, dealer, preset, drawn, discard_drawn):
+    env, _ = setup_env(players, dealer, preset, drawn)
+    tile = drawn if discard_drawn else 44
+    discard(env, dealer, tile)
+    tedashi = preset == "mjsoul" or not discard_drawn
+    check_history(env, players, dealer, tile, tedashi, tile if tedashi else None)
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+def test_later_draws_remain_tsumogiri(players, preset):
+    env, _ = setup_env(players, 0, preset)
+    discard(env, 0, 44)
+    pass_responses(env)
+    # Nondealers' first draws and the dealer's second draw use the usual rule.
+    for actor in [*range(1, players), 0]:
+        assert env.current_player == actor
+        tile = env.drawn_tile
+        discard(env, actor, tile)
+        check_history(env, players, actor, tile, False, 44 if actor == 0 else None)
+        pass_responses(env)
+    env.reset(oya=0)
+    tile = env.drawn_tile
+    discard(env, 0, tile)
+    tedashi = preset == "mjsoul"
+    check_history(env, players, 0, tile, tedashi, tile if tedashi else None)
+
+
+@pytest.mark.parametrize("players,opening", [(3, ActionType.ANKAN), (4, ActionType.ANKAN), (3, ActionType.KITA)])
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+def test_initial_replacement_draw_can_be_tsumogiri(players, opening, preset):
+    env, _ = setup_env(players, 0, preset, drawn=109, opening=opening)
+    action = next(a for a in env._get_legal_actions(0) if a.action_type == opening)
+    env.step({0: action})
+    pass_responses(env)
+    assert env.current_player == 0
+    assert not env.is_first_turn
+    tile = env.drawn_tile
+    discard(env, 0, tile)
+    check_history(env, players, 0, tile, False, None)
+
+
+@pytest.mark.parametrize("players", [3, 4])
+@pytest.mark.parametrize("forced", [False, True])
+def test_initial_discard_convention_is_configurable(players, forced):
+    rule = GameRule(dealer_first_discard_is_tedashi=forced)
+    assert rule.dealer_first_discard_is_tedashi is forced
+    assert "dealer_first_discard_is_tedashi=" in repr(rule)
+    env, _ = setup_env(players, 0, "tenhou", rule=rule)
+    discard(env, 0, 53)
+    check_history(env, players, 0, 53, forced, 53 if forced else None)
+
+
+@pytest.mark.parametrize("preset", ["mjsoul", "tenhou"])
+def test_initial_discard_sequence_candidates_match_metadata(preset):
+    # Use the representative red tile ID so candidate lookup is unambiguous.
+    env, observations = setup_env(4, 0, preset, drawn=52)
+    obs = observations[0]
+    restored = Observation.deserialize_from_base64(obs.serialize_to_base64())
+    for view in (obs, restored):
+        assert view.drawn_tile == 52
+        assert view.forced_tedashi is (preset == "mjsoul")
+        candidates = list(memoryview(view.encode_seq_candidates()).cast("H"))
+        moqie = 0 if preset == "mjsoul" else 1
+        assert [10, moqie, 2, 3] in [candidates[i : i + 4] for i in range(0, len(candidates), 4)]
+
+
+@pytest.mark.parametrize("players", [3, 4])
+def test_observation_without_tedashi_convention_remains_readable(players):
+    env, _ = setup_env(players, 0, "mjsoul")
+    obs = env.get_observation(0)
+    payload = json.loads(base64.b64decode(obs.serialize_to_base64()))
+    payload.pop("forced_tedashi", None)
+    cls = Observation3P if players == 3 else Observation
+    restored = cls.deserialize_from_base64(base64.b64encode(json.dumps(payload).encode()).decode())
+    assert restored.drawn_tile == 53
+    assert not restored.forced_tedashi

--- a/tests/test_observation_tile_features.py
+++ b/tests/test_observation_tile_features.py
@@ -163,7 +163,7 @@ def test_riichi_discard_features_after_separate_declaration(players, preset, tsu
         for observer in range(players):
             obs = env.get_observation(observer)
             assert obs.riichi_sutehais == [tile] + [None] * (players - 1)
-            assert obs.last_tedashis[0] == (None if tsumogiri else tile)
+            assert obs.last_tedashis[0] == (None if tsumogiri and preset == "tenhou" else tile)
             if observer != 0:
                 expected = [tile_types(players).index(tile // 4) / (len(tile_types(players)) - 1), 0.0, 1.0]
                 assert list(memoryview(obs.encode_riichi_sutehais()).cast("f")[:3]) == pytest.approx(expected)


### PR DESCRIPTION
Treat the dealer's uninterrupted first discard as tedashi in the MJSoul preset for both 3P and 4P.