### PR TITLE
Bump version to 0.4.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "riichienv-core"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "base64",
  "criterion",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "riichienv-python"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "pyo3",
  "riichienv-core",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "riichienv-wasm"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "getrandom",
  "riichienv-core",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riichienv"
-version = "0.4.9"
+version = "0.4.10"
 authors = [
     { name="Kohei Ozaki", email="19337+smly@users.noreply.github.com" },
 ]

--- a/riichienv-core/Cargo.toml
+++ b/riichienv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riichienv-core"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 license = "Apache-2.0"
 description = "Japanese Mahjong (Riichi) game engine with MJAI protocol support"

--- a/riichienv-ml/pyproject.toml
+++ b/riichienv-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "riichienv-ml"
-version = "0.4.9"
+version = "0.4.10"
 description = "Mahjong RL training pipeline: GRP reward shaping, offline CQL, and online DQN+CQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/riichienv-python/Cargo.toml
+++ b/riichienv-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riichienv-python"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/riichienv-wasm/Cargo.toml
+++ b/riichienv-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riichienv-wasm"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 license = "Apache-2.0"
 description = "WASM bindings for RiichiEnv mahjong game engine"

--- a/uv.lock
+++ b/uv.lock
@@ -2636,7 +2636,7 @@ wheels = [
 
 [[package]]
 name = "riichienv"
-version = "0.4.9"
+version = "0.4.10"
 source = { editable = "." }
 dependencies = [
     { name = "ipython" },
@@ -2675,7 +2675,7 @@ dev = [
 
 [[package]]
 name = "riichienv-ml"
-version = "0.4.9"
+version = "0.4.10"
 source = { editable = "riichienv-ml" }
 dependencies = [
     { name = "dotenv" },


### PR DESCRIPTION
Bump the Rust crates and Python packages to 0.4.10, and refresh Cargo.lock and uv.lock without upgrading external dependencies.